### PR TITLE
schema-aware table loading, full loads in health_schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "start": "node dist/server.js",
     "dev": "bun --watch src/server.ts",
     "typecheck": "tsc --noEmit",
+    "test": "bun test",
     "prepublishOnly": "npm run build"
   },
   "keywords": [

--- a/src/db/loader.test.ts
+++ b/src/db/loader.test.ts
@@ -1,0 +1,207 @@
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { HealthDataDB } from './database';
+import { FileCatalog } from './catalog';
+import { TableLoader } from './loader';
+
+const RECENT_ROWS = 120;
+const OLD_ROWS = 5;
+
+function formatTimestamp(date: Date): string {
+  return `${date.toISOString().slice(0, 19).replace('T', ' ')} +0000`;
+}
+
+function daysAgo(days: number): Date {
+  const date = new Date();
+  date.setDate(date.getDate() - days);
+  return date;
+}
+
+function writeCsv(dir: string, fileName: string, header: string, rows: string[]): void {
+  const lines = ['sep=,', header, ...rows];
+  writeFileSync(join(dir, fileName), lines.join('\r\n') + '\r\n');
+}
+
+let dataDir: string;
+let db: HealthDataDB;
+let catalog: FileCatalog;
+let loader: TableLoader;
+
+beforeAll(async () => {
+  dataDir = mkdtempSync(join(tmpdir(), 'health-loader-test-'));
+
+  // Quantity shape: has unit and numeric value
+  const heartRateRows: string[] = [];
+  for (let i = 0; i < RECENT_ROWS; i++) {
+    const start = formatTimestamp(daysAgo(1 + (i % 60)));
+    heartRateRows.push(
+      `HKQuantityTypeIdentifierHeartRate,Apple Watch,10.0,Watch7,1,${start},${start},count/min,${60 + (i % 40)}`
+    );
+  }
+  for (let i = 0; i < OLD_ROWS; i++) {
+    const start = formatTimestamp(daysAgo(200 + i));
+    heartRateRows.push(
+      `HKQuantityTypeIdentifierHeartRate,Apple Watch,10.0,Watch7,1,${start},${start},count/min,${50 + i}`
+    );
+  }
+  writeCsv(
+    dataDir,
+    'HKQuantityTypeIdentifierHeartRate.csv',
+    'type,sourceName,sourceVersion,productType,device,startDate,endDate,unit,value',
+    heartRateRows
+  );
+
+  // Category shape: no unit column, value is a text label
+  const stages = [
+    'HKCategoryValueSleepAnalysisAsleepCore',
+    'HKCategoryValueSleepAnalysisAsleepDeep',
+    'HKCategoryValueSleepAnalysisAsleepREM',
+    'HKCategoryValueSleepAnalysisInBed'
+  ];
+  const sleepRows: string[] = [];
+  for (let i = 0; i < 40; i++) {
+    const start = formatTimestamp(daysAgo(1 + (i % 30)));
+    sleepRows.push(
+      `HKCategoryTypeIdentifierSleepAnalysis,Apple Watch,10.0,Watch7,1,${start},${start},${stages[i % stages.length]}`
+    );
+  }
+  for (let i = 0; i < OLD_ROWS; i++) {
+    const start = formatTimestamp(daysAgo(200 + i));
+    sleepRows.push(
+      `HKCategoryTypeIdentifierSleepAnalysis,Apple Watch,10.0,Watch7,1,${start},${start},${stages[0]}`
+    );
+  }
+  writeCsv(
+    dataDir,
+    'HKCategoryTypeIdentifierSleepAnalysis.csv',
+    'type,sourceName,sourceVersion,productType,device,startDate,endDate,value',
+    sleepRows
+  );
+
+  // Workout shape: no unit and no value column
+  const workoutRows: string[] = [];
+  for (let i = 0; i < 10; i++) {
+    const start = formatTimestamp(daysAgo(1 + i));
+    workoutRows.push(
+      `HKWorkoutActivityTypeRunning,Apple Watch,10.0,${start},${start},${1800 + i},${400 + i},${5.5 + i}`
+    );
+  }
+  writeCsv(
+    dataDir,
+    'HKWorkoutTypeIdentifierTest.csv',
+    'type,sourceName,sourceVersion,startDate,endDate,duration,totalEnergyBurned,totalDistance',
+    workoutRows
+  );
+
+  db = new HealthDataDB({ dataDir, maxMemoryMB: 512 });
+  await db.initialize();
+  catalog = new FileCatalog(dataDir);
+  await catalog.initialize();
+  loader = new TableLoader(db, catalog);
+});
+
+afterAll(async () => {
+  await db.close();
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe('TableLoader quantity tables', () => {
+  test('loads only rows inside the rolling window', async () => {
+    await loader.ensureTableLoaded('hkquantitytypeidentifierheartrate');
+
+    const result = await db.execute(
+      'SELECT COUNT(*) as count FROM hkquantitytypeidentifierheartrate'
+    );
+    expect(Number(result[0].count)).toBe(RECENT_ROWS);
+  });
+
+  test('keeps a numeric value, a valueText copy, and the unit', async () => {
+    await loader.ensureTableLoaded('hkquantitytypeidentifierheartrate');
+
+    const rows = await db.execute(`
+      SELECT value, valueText, unit
+      FROM hkquantitytypeidentifierheartrate
+      LIMIT 1
+    `);
+    expect(typeof rows[0].value).toBe('number');
+    expect(typeof rows[0].valueText).toBe('string');
+    expect(rows[0].unit).toBe('count/min');
+
+    const numeric = await db.execute(`
+      SELECT AVG(value) as avg_value
+      FROM hkquantitytypeidentifierheartrate
+    `);
+    expect(Number(numeric[0].avg_value)).toBeGreaterThan(0);
+  });
+
+  test('ensureTableLoaded is idempotent', async () => {
+    await loader.ensureTableLoaded('hkquantitytypeidentifierheartrate');
+    await loader.ensureTableLoaded('hkquantitytypeidentifierheartrate');
+
+    const result = await db.execute(
+      'SELECT COUNT(*) as count FROM hkquantitytypeidentifierheartrate'
+    );
+    expect(Number(result[0].count)).toBe(RECENT_ROWS);
+  });
+});
+
+describe('TableLoader category tables', () => {
+  test('loads without error and preserves the stage label in valueText', async () => {
+    await loader.ensureTableLoaded('hkcategorytypeidentifiersleepanalysis');
+
+    const rows = await db.execute(`
+      SELECT valueText, value
+      FROM hkcategorytypeidentifiersleepanalysis
+      WHERE valueText = 'HKCategoryValueSleepAnalysisAsleepDeep'
+      LIMIT 1
+    `);
+    expect(rows.length).toBe(1);
+    expect(rows[0].valueText).toBe('HKCategoryValueSleepAnalysisAsleepDeep');
+    expect(rows[0].value).toBeNull();
+  });
+
+  test('has no unit column', async () => {
+    await loader.ensureTableLoaded('hkcategorytypeidentifiersleepanalysis');
+
+    const columns = await db.execute(`
+      SELECT column_name
+      FROM information_schema.columns
+      WHERE table_name = 'hkcategorytypeidentifiersleepanalysis'
+    `);
+    const names = columns.map((col: any) => String(col.column_name).toLowerCase());
+    expect(names).not.toContain('unit');
+    expect(names).toContain('valuetext');
+  });
+});
+
+describe('TableLoader workout tables', () => {
+  test('loads without error and keeps workout columns queryable', async () => {
+    await loader.ensureTableLoaded('hkworkouttypeidentifiertest');
+
+    const rows = await db.execute(`
+      SELECT duration, totalEnergyBurned, totalDistance
+      FROM hkworkouttypeidentifiertest
+      ORDER BY startDate DESC
+      LIMIT 1
+    `);
+    expect(rows.length).toBe(1);
+    expect(Number(rows[0].duration)).toBeGreaterThan(0);
+    expect(Number(rows[0].totalEnergyBurned)).toBeGreaterThan(0);
+    expect(Number(rows[0].totalDistance)).toBeGreaterThan(0);
+  });
+
+  test('has no value column', async () => {
+    await loader.ensureTableLoaded('hkworkouttypeidentifiertest');
+
+    const columns = await db.execute(`
+      SELECT column_name
+      FROM information_schema.columns
+      WHERE table_name = 'hkworkouttypeidentifiertest'
+    `);
+    const names = columns.map((col: any) => String(col.column_name).toLowerCase());
+    expect(names).not.toContain('value');
+    expect(names).not.toContain('valuetext');
+  });
+});

--- a/src/db/loader.ts
+++ b/src/db/loader.ts
@@ -78,35 +78,68 @@ export class TableLoader {
   private async cleanAndOptimizeTable(stagingTable: string, finalTable: string): Promise<void> {
     // Drop existing table if it exists
     await this.db.run(`DROP TABLE IF EXISTS ${finalTable}`);
-    
+
+    // Health exports come in several shapes. Quantity CSVs have unit and value,
+    // category CSVs have no unit, workout CSVs have neither and carry duration
+    // and energy columns instead. Build the projection from the columns that
+    // are actually present so every shape loads.
+    const stagingColumns = await this.db.execute(`
+      SELECT column_name
+      FROM information_schema.columns
+      WHERE table_name = '${stagingTable}'
+      ORDER BY ordinal_position
+    `);
+    const columnNames: string[] = stagingColumns.map((col: any) => col.column_name);
+    const columnByLower = new Map<string, string>();
+    for (const name of columnNames) {
+      columnByLower.set(name.toLowerCase(), name);
+    }
+
+    const startDateCol = columnByLower.get('startdate');
+    const endDateCol = columnByLower.get('enddate');
+    const valueCol = columnByLower.get('value');
+    const typeCol = columnByLower.get('type');
+
+    const selectParts: string[] = [];
+    for (const name of columnNames) {
+      const lower = name.toLowerCase();
+      if (lower === 'startdate' || lower === 'enddate') {
+        selectParts.push(`TRY_CAST(SUBSTR(${name}, 1, 19) AS TIMESTAMP) as ${name}`);
+      } else if (lower === 'value') {
+        // Category rows hold text labels like HKCategoryValueSleepAnalysisAsleepCore.
+        // Keep the numeric cast for quantity queries and keep the raw label in valueText.
+        selectParts.push(`TRY_CAST(${name} AS DOUBLE) as ${name}`);
+        selectParts.push(`CAST(${name} AS VARCHAR) as valueText`);
+      } else {
+        selectParts.push(name);
+      }
+    }
+
+    const whereClause = valueCol ? `\n      WHERE ${valueCol} IS NOT NULL` : '';
+
     // Create optimized table with proper types and indexes
     await this.db.run(`
       CREATE TABLE ${finalTable} AS
-      SELECT 
-        type,
-        sourceName,
-        sourceVersion,
-        unit,
-        TRY_CAST(SUBSTR(startDate, 1, 19) AS TIMESTAMP) as startDate,
-        TRY_CAST(SUBSTR(endDate, 1, 19) AS TIMESTAMP) as endDate,
-        TRY_CAST(value AS DOUBLE) as value,
-        device,
-        productType
-      FROM ${stagingTable}
-      WHERE value IS NOT NULL
+      SELECT
+        ${selectParts.join(',\n        ')}
+      FROM ${stagingTable}${whereClause}
     `);
-    
+
     // Create indexes for common query patterns
-    await this.db.run(`
-      CREATE INDEX IF NOT EXISTS idx_${finalTable}_startdate 
-      ON ${finalTable}(startDate)
-    `);
-    
-    await this.db.run(`
-      CREATE INDEX IF NOT EXISTS idx_${finalTable}_type 
-      ON ${finalTable}(type)
-    `);
-    
+    if (startDateCol) {
+      await this.db.run(`
+        CREATE INDEX IF NOT EXISTS idx_${finalTable}_startdate
+        ON ${finalTable}(${startDateCol})
+      `);
+    }
+
+    if (typeCol) {
+      await this.db.run(`
+        CREATE INDEX IF NOT EXISTS idx_${finalTable}_type
+        ON ${finalTable}(${typeCol})
+      `);
+    }
+
     // Drop staging table
     await this.db.run(`DROP TABLE ${stagingTable}`);
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -48,7 +48,7 @@ const optimizer = new QueryOptimizer(loader);
 // Initialize tools
 const queryTool = new HealthQueryTool(db, cache, optimizer);
 const reportTool = new HealthReportTool(db, cache);
-const schemaTool = new HealthSchemaTool(db, catalog);
+const schemaTool = new HealthSchemaTool(db, catalog, loader);
 
 // Create MCP server
 const server = new Server({

--- a/src/tools/health-schema.test.ts
+++ b/src/tools/health-schema.test.ts
@@ -1,0 +1,130 @@
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { HealthDataDB } from '../db/database';
+import { FileCatalog } from '../db/catalog';
+import { TableLoader } from '../db/loader';
+import { HealthSchemaTool } from './health-schema';
+
+const RECENT_HEART_RATE_ROWS = 120;
+
+function formatTimestamp(date: Date): string {
+  return `${date.toISOString().slice(0, 19).replace('T', ' ')} +0000`;
+}
+
+function daysAgo(days: number): Date {
+  const date = new Date();
+  date.setDate(date.getDate() - days);
+  return date;
+}
+
+function writeCsv(dir: string, fileName: string, header: string, rows: string[]): void {
+  const lines = ['sep=,', header, ...rows];
+  writeFileSync(join(dir, fileName), lines.join('\r\n') + '\r\n');
+}
+
+let dataDir: string;
+let db: HealthDataDB;
+let catalog: FileCatalog;
+let loader: TableLoader;
+let schema: any;
+
+beforeAll(async () => {
+  dataDir = mkdtempSync(join(tmpdir(), 'health-schema-test-'));
+
+  const heartRateRows: string[] = [];
+  for (let i = 0; i < RECENT_HEART_RATE_ROWS; i++) {
+    const start = formatTimestamp(daysAgo(1 + (i % 60)));
+    heartRateRows.push(
+      `HKQuantityTypeIdentifierHeartRate,Apple Watch,10.0,Watch7,1,${start},${start},count/min,${60 + (i % 40)}`
+    );
+  }
+  for (let i = 0; i < 5; i++) {
+    const start = formatTimestamp(daysAgo(200 + i));
+    heartRateRows.push(
+      `HKQuantityTypeIdentifierHeartRate,Apple Watch,10.0,Watch7,1,${start},${start},count/min,${50 + i}`
+    );
+  }
+  writeCsv(
+    dataDir,
+    'HKQuantityTypeIdentifierHeartRate.csv',
+    'type,sourceName,sourceVersion,productType,device,startDate,endDate,unit,value',
+    heartRateRows
+  );
+
+  const stages = [
+    'HKCategoryValueSleepAnalysisAsleepCore',
+    'HKCategoryValueSleepAnalysisAsleepDeep',
+    'HKCategoryValueSleepAnalysisAsleepREM',
+    'HKCategoryValueSleepAnalysisInBed'
+  ];
+  const sleepRows: string[] = [];
+  for (let i = 0; i < 40; i++) {
+    const start = formatTimestamp(daysAgo(1 + (i % 30)));
+    sleepRows.push(
+      `HKCategoryTypeIdentifierSleepAnalysis,Apple Watch,10.0,Watch7,1,${start},${start},${stages[i % stages.length]}`
+    );
+  }
+  writeCsv(
+    dataDir,
+    'HKCategoryTypeIdentifierSleepAnalysis.csv',
+    'type,sourceName,sourceVersion,productType,device,startDate,endDate,value',
+    sleepRows
+  );
+
+  db = new HealthDataDB({ dataDir, maxMemoryMB: 512 });
+  await db.initialize();
+  catalog = new FileCatalog(dataDir);
+  await catalog.initialize();
+  loader = new TableLoader(db, catalog);
+
+  const schemaTool = new HealthSchemaTool(db, catalog, loader);
+  schema = await schemaTool.execute();
+});
+
+afterAll(async () => {
+  await db.close();
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe('HealthSchemaTool', () => {
+  test('loads the full rolling window, not a 100 row sample', async () => {
+    const result = await db.execute(
+      'SELECT COUNT(*) as count FROM hkquantitytypeidentifierheartrate'
+    );
+    expect(Number(result[0].count)).toBe(RECENT_HEART_RATE_ROWS);
+  });
+
+  test('records the real row count in the catalog', () => {
+    const entry = catalog.getEntry('hkquantitytypeidentifierheartrate');
+    expect(entry?.loaded).toBe(true);
+    expect(Number(entry?.rowCount)).toBe(RECENT_HEART_RATE_ROWS);
+  });
+
+  test('reports the primary unit for a quantity table', () => {
+    const details = schema.tableDetails['hkquantitytypeidentifierheartrate'];
+    expect(details.error).toBeUndefined();
+    expect(details.primaryUnit).toBe('count/min');
+  });
+
+  test('handles a category table with no unit column', () => {
+    const details = schema.tableDetails['hkcategorytypeidentifiersleepanalysis'];
+    expect(details.error).toBeUndefined();
+    expect(details.primaryUnit).toBe('unknown');
+    expect(details.units).toEqual([]);
+
+    const columnNames = details.columns.map((col: any) => String(col.name).toLowerCase());
+    expect(columnNames).toContain('valuetext');
+    expect(columnNames).not.toContain('unit');
+  });
+
+  test('leaves tables with no unit out of the unit reference', () => {
+    expect(schema.unitReference['hkquantitytypeidentifierheartrate']).toBe('count/min');
+    expect(schema.unitReference['hkcategorytypeidentifiersleepanalysis']).toBeUndefined();
+  });
+
+  test('tells the client about valueText', () => {
+    expect(schema.queryTips.some((tip: string) => tip.includes('valueText'))).toBe(true);
+  });
+});

--- a/src/tools/health-schema.ts
+++ b/src/tools/health-schema.ts
@@ -1,13 +1,16 @@
 import type { HealthDataDB } from '../db/database';
 import type { FileCatalog } from '../db/catalog';
+import type { TableLoader } from '../db/loader';
 
 export class HealthSchemaTool {
   private db: HealthDataDB;
   private catalog: FileCatalog;
-  
-  constructor(db: HealthDataDB, catalog: FileCatalog) {
+  private loader: TableLoader;
+
+  constructor(db: HealthDataDB, catalog: FileCatalog, loader: TableLoader) {
     this.db = db;
     this.catalog = catalog;
+    this.loader = loader;
   }
   
   async execute(): Promise<any> {
@@ -48,21 +51,32 @@ export class HealthSchemaTool {
     // Get schema information for sample tables
     for (const tableName of sampleTables) {
       try {
-        // Ensure table is loaded
+        // Load the full rolling window through the loader so later queries see all rows
+        await this.loader.ensureTableLoaded(tableName);
+
+        // The loader skips tables with no rows in the rolling window, so the table
+        // may not exist. Report that instead of querying a missing table.
         const entry = this.catalog.getEntry(tableName);
         if (!entry?.loaded) {
-          // Load a small sample to get schema
-          await this.loadTableSample(tableName, entry!.path);
+          schema.tableDetails[tableName] = {
+            note: 'no data in the rolling window (last 90 days)',
+            available: false
+          };
+          continue;
         }
-        
+
         // Get column information
         const columns = await this.db.execute(`
-          SELECT column_name, data_type 
-          FROM information_schema.columns 
+          SELECT column_name, data_type
+          FROM information_schema.columns
           WHERE table_name = '${tableName}'
           ORDER BY ordinal_position
         `);
-        
+
+        const hasUnitColumn = columns.some(
+          (col: any) => String(col.column_name).toLowerCase() === 'unit'
+        );
+
         // Get sample data
         const sampleData = await this.db.execute(`
           SELECT * FROM ${tableName}
@@ -70,15 +84,18 @@ export class HealthSchemaTool {
           LIMIT 3
         `);
 
-        // Get distinct units for this table (sorted by frequency)
-        const unitInfo = await this.db.execute(`
-          SELECT unit, COUNT(*) as count
-          FROM ${tableName}
-          WHERE unit IS NOT NULL
-          GROUP BY unit
-          ORDER BY count DESC
-        `);
-        
+        // Get distinct units for this table (sorted by frequency).
+        // Category and workout tables have no unit column.
+        const unitInfo = hasUnitColumn
+          ? await this.db.execute(`
+              SELECT unit, COUNT(*) as count
+              FROM ${tableName}
+              WHERE unit IS NOT NULL
+              GROUP BY unit
+              ORDER BY count DESC
+            `)
+          : [];
+
         // Get data statistics
         const stats = await this.db.execute(`
           SELECT 
@@ -122,6 +139,7 @@ export class HealthSchemaTool {
     schema.queryTips = [
       "IMPORTANT: Always check the 'unit' column - units vary by source device (e.g., km vs m vs mi)",
       "Include 'unit' in SELECT statements when querying values to verify units",
+      "Category tables (sleep stages, stand hours) keep their text label in the valueText column - the numeric value column is NULL for these rows",
       "Table names are lowercase versions of the CSV filenames",
       "Always filter by date: WHERE startDate >= 'YYYY-MM-DD'",
       "Use DATE(startDate) for daily grouping",
@@ -138,55 +156,5 @@ export class HealthSchemaTool {
     }
 
     return schema;
-  }
-  
-  private async loadTableSample(tableName: string, filePath: string): Promise<void> {
-    const tempTableName = `${tableName}_sample`;
-    
-    try {
-      // Load just a few rows to get schema
-      await this.db.run(`
-        CREATE TABLE ${tempTableName} AS
-        SELECT * FROM read_csv('${filePath}',
-          header = true,
-          skip = 1,
-          delim = ',',
-          quote = '"',
-          escape = '"',
-          ignore_errors = true,
-          null_padding = true,
-          new_line = '\\r\\n'
-        )
-        LIMIT 100
-      `);
-      
-      // Clean up timestamps and create final table
-      await this.db.run(`
-        CREATE TABLE ${tableName} AS
-        SELECT 
-          type,
-          sourceName,
-          sourceVersion,
-          unit,
-          TRY_CAST(SUBSTR(startDate, 1, 19) AS TIMESTAMP) as startDate,
-          TRY_CAST(SUBSTR(endDate, 1, 19) AS TIMESTAMP) as endDate,
-          TRY_CAST(value AS DOUBLE) as value,
-          device,
-          productType
-        FROM ${tempTableName}
-        WHERE value IS NOT NULL
-      `);
-      
-      // Clean up
-      await this.db.run(`DROP TABLE ${tempTableName}`);
-      
-      // Mark as loaded in catalog
-      this.catalog.markLoaded(tableName, 100); // Approximate count
-      
-    } catch (error) {
-      // Clean up on error
-      await this.db.run(`DROP TABLE IF EXISTS ${tempTableName}`);
-      throw error;
-    }
   }
 }


### PR DESCRIPTION
## Summary

First of three fix batches for the recent issue reports. This one fixes table loading so all CSV shapes load, and stops `health_schema` from silently truncating tables.

Fixes #6, fixes #8. Partial fix for #9 (stage labels now load; the sleep report SQL is a follow-up PR) and #11 (workout-shaped CSVs now load; the catalog regex is a follow-up PR).

## Changes

**derive table columns from the csv instead of a fixed list**

`cleanAndOptimizeTable()` assumed the quantity-csv shape (`unit` + numeric `value`). Category CSVs have no `unit` column, and workout CSVs have neither `unit` nor `value`, so both failed with binder errors. Category labels like `HKCategoryValueSleepAnalysisAsleepCore` were also cast to `NULL` by `TRY_CAST(value AS DOUBLE)`.

The loader now inspects the staging table and builds the projection from the columns that exist:

- `startDate` / `endDate` get the timestamp cast
- `value` becomes two columns: `value` (numeric cast, unchanged for quantity queries) and `valueText` (raw label, so sleep stages are queryable)
- all other columns pass through unchanged
- the `WHERE value IS NOT NULL` filter and the two indexes apply only when their columns exist

No table-name sniffing and no fabricated columns: the loaded table always matches the source CSV.

**load full tables in health_schema instead of 100-row samples**

`loadTableSample()` loaded 100 rows and then marked the table as loaded in the catalog. `ensureTableLoaded()` saw the flag and skipped the real load, so every later `health_query` and `health_report` ran against 100 rows with no warning.

The sample loader is deleted. `HealthSchemaTool` now takes the `TableLoader` and calls `ensureTableLoaded()`, which loads the full 90-day rolling window on one shared path. Tables with no rows in the window get a clear note instead of an error, the unit query only runs when the table has a `unit` column, and a query tip tells clients about `valueText`.

## Tests

New `bun test` suite (13 tests) with generated fixtures for all three CSV shapes, including:

- a 120-row fixture that fails if the 100-row truncation ever returns (#8 regression test)
- out-of-window rows that prove the 90-day filter works
- stage-label round-trip through `valueText`

The tests were mutation-checked: re-adding `LIMIT 100` or removing the `valueText` projection each breaks 4 tests.

## Follow-up PRs

- catalog: match `HKWorkoutActivityType*` files, rescan on demand (#11, #12)
- report tool: load its tables, fix sleep and workout SQL (#9, #10)
