### PR TITLE
catalog workout files, rescan on demand, honest load count

### DIFF
--- a/src/db/catalog.test.ts
+++ b/src/db/catalog.test.ts
@@ -1,0 +1,128 @@
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { FileCatalog } from './catalog';
+
+function formatTimestamp(date: Date): string {
+  return `${date.toISOString().slice(0, 19).replace('T', ' ')} +0000`;
+}
+
+function daysAgo(days: number): Date {
+  const date = new Date();
+  date.setDate(date.getDate() - days);
+  return date;
+}
+
+function writeCsv(dir: string, fileName: string, header: string, rows: string[]): void {
+  const lines = ['sep=,', header, ...rows];
+  writeFileSync(join(dir, fileName), lines.join('\r\n') + '\r\n');
+}
+
+const QUANTITY_HEADER =
+  'type,sourceName,sourceVersion,productType,device,startDate,endDate,unit,value';
+const WORKOUT_HEADER =
+  'type,sourceName,sourceVersion,startDate,endDate,duration,totalEnergyBurned,totalDistance';
+
+function quantityRow(): string {
+  const start = formatTimestamp(daysAgo(1));
+  return `HKQuantityTypeIdentifierHeartRate,Apple Watch,10.0,Watch7,1,${start},${start},count/min,72`;
+}
+
+function workoutRow(type: string): string {
+  const start = formatTimestamp(daysAgo(1));
+  return `${type},Apple Watch,10.0,${start},${start},1800,400,5.5`;
+}
+
+let dataDir: string;
+let catalog: FileCatalog;
+
+beforeAll(async () => {
+  dataDir = mkdtempSync(join(tmpdir(), 'health-catalog-test-'));
+
+  writeCsv(dataDir, 'HKQuantityTypeIdentifierHeartRate.csv', QUANTITY_HEADER, [quantityRow()]);
+  writeCsv(dataDir, 'HKWorkoutActivityType.csv', WORKOUT_HEADER, [
+    workoutRow('HKWorkoutActivityTypeRunning')
+  ]);
+  writeCsv(dataDir, 'HKWorkoutActivityTypeRunning.csv', WORKOUT_HEADER, [
+    workoutRow('HKWorkoutActivityTypeRunning')
+  ]);
+
+  // Neither of these should be catalogued.
+  writeFileSync(join(dataDir, 'notes.txt'), 'not health data\n');
+  writeCsv(dataDir, 'Workout.csv', WORKOUT_HEADER, [workoutRow('HKWorkoutActivityTypeCycling')]);
+
+  catalog = new FileCatalog(dataDir);
+  await catalog.initialize();
+});
+
+afterAll(() => {
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe('FileCatalog scanning', () => {
+  test('catalogues a quantity export', () => {
+    expect(catalog.getAllTables()).toContain('hkquantitytypeidentifierheartrate');
+  });
+
+  test('catalogues a single file workout export', () => {
+    expect(catalog.getAllTables()).toContain('hkworkoutactivitytype');
+  });
+
+  test('catalogues a per type workout export', () => {
+    expect(catalog.getAllTables()).toContain('hkworkoutactivitytyperunning');
+  });
+
+  test('records the path for a workout export', () => {
+    expect(catalog.getTablePath('hkworkoutactivitytyperunning')).toBe(
+      join(dataDir, 'HKWorkoutActivityTypeRunning.csv')
+    );
+  });
+
+  test('ignores files that are not health exports', () => {
+    const tables = catalog.getAllTables();
+    expect(tables).not.toContain('notes');
+    expect(tables).not.toContain('workout');
+  });
+});
+
+describe('FileCatalog refresh', () => {
+  test('picks up a file written after initialize', async () => {
+    const lateDir = mkdtempSync(join(tmpdir(), 'health-catalog-late-'));
+    const lateCatalog = new FileCatalog(lateDir);
+    await lateCatalog.initialize();
+    expect(lateCatalog.getAllTables()).toEqual([]);
+
+    writeCsv(lateDir, 'HKQuantityTypeIdentifierStepCount.csv', QUANTITY_HEADER, [quantityRow()]);
+    await lateCatalog.refresh();
+
+    expect(lateCatalog.getAllTables()).toContain('hkquantitytypeidentifierstepcount');
+    rmSync(lateDir, { recursive: true, force: true });
+  });
+
+  test('preserves loaded state for tables it already knows', async () => {
+    catalog.markLoaded('hkquantitytypeidentifierheartrate', 42);
+    await catalog.refresh();
+
+    const entry = catalog.getEntry('hkquantitytypeidentifierheartrate');
+    expect(entry?.loaded).toBe(true);
+    expect(entry?.rowCount).toBe(42);
+  });
+
+  test('keeps entries for files that disappear', async () => {
+    const goneDir = mkdtempSync(join(tmpdir(), 'health-catalog-gone-'));
+    writeCsv(goneDir, 'HKQuantityTypeIdentifierHeartRate.csv', QUANTITY_HEADER, [quantityRow()]);
+
+    const goneCatalog = new FileCatalog(goneDir);
+    await goneCatalog.initialize();
+    goneCatalog.markLoaded('hkquantitytypeidentifierheartrate', 7);
+
+    rmSync(join(goneDir, 'HKQuantityTypeIdentifierHeartRate.csv'));
+    await goneCatalog.refresh();
+
+    const entry = goneCatalog.getEntry('hkquantitytypeidentifierheartrate');
+    expect(entry?.loaded).toBe(true);
+    expect(entry?.rowCount).toBe(7);
+    rmSync(goneDir, { recursive: true, force: true });
+  });
+});

--- a/src/db/catalog.ts
+++ b/src/db/catalog.ts
@@ -13,17 +13,33 @@ export class FileCatalog {
   async initialize(): Promise<void> {
     await this.scanDirectory();
   }
-  
+
+  // Re-scan the data directory so files added after startup become queryable.
+  async refresh(): Promise<void> {
+    await this.scanDirectory();
+  }
+
   private async scanDirectory(): Promise<void> {
     try {
       const files = await readdir(this.dataDir);
-      
+
       for (const file of files) {
-        const match = file.match(/^(HK\w+TypeIdentifier\w+).*\.csv$/);
+        // Workout exports are named HKWorkoutActivityType.csv or
+        // HKWorkoutActivityTypeRunning.csv, with no literal "TypeIdentifier".
+        const match = file.match(/^(HK\w+TypeIdentifier\w+).*\.csv$/)
+          || file.match(/^(HKWorkoutActivityType\w*).*\.csv$/);
         if (match) {
           const tableName = match[1].toLowerCase();
+          const path = join(this.dataDir, file);
+          const existing = this.catalog.get(tableName);
+
+          // Keep loaded state for tables we have already seen at this path.
+          if (existing && existing.path === path) {
+            continue;
+          }
+
           this.catalog.set(tableName, {
-            path: join(this.dataDir, file),
+            path,
             loaded: false,
             rowCount: null
           });

--- a/src/tools/health-schema.test.ts
+++ b/src/tools/health-schema.test.ts
@@ -127,4 +127,48 @@ describe('HealthSchemaTool', () => {
   test('tells the client about valueText', () => {
     expect(schema.queryTips.some((tip: string) => tip.includes('valueText'))).toBe(true);
   });
+
+  test('reports tables in memory instead of a misleading loaded count', () => {
+    expect(schema.summary.loadedTables).toBeUndefined();
+    expect(schema.summary.tablesInMemory).toBeGreaterThan(0);
+    expect(schema.summary.loadingNote).toContain('on demand');
+  });
+});
+
+describe('HealthSchemaTool rescan', () => {
+  test('finds a workout export written after the first execute', async () => {
+    expect(schema.availableTables).not.toContain('hkworkoutactivitytyperunning');
+
+    const workoutRows: string[] = [];
+    for (let i = 0; i < 10; i++) {
+      const start = formatTimestamp(daysAgo(1 + i));
+      workoutRows.push(
+        `HKWorkoutActivityTypeRunning,Apple Watch,10.0,${start},${start},${1800 + i},${400 + i},${5.5 + i}`
+      );
+    }
+    writeCsv(
+      dataDir,
+      'HKWorkoutActivityTypeRunning.csv',
+      'type,sourceName,sourceVersion,startDate,endDate,duration,totalEnergyBurned,totalDistance',
+      workoutRows
+    );
+
+    const schemaTool = new HealthSchemaTool(db, catalog, loader);
+    const rescanned = await schemaTool.execute();
+
+    expect(rescanned.availableTables).toContain('hkworkoutactivitytyperunning');
+    expect(rescanned.commonPatterns.workouts).toContain('hkworkoutactivitytyperunning');
+
+    // The workout CSV has no unit and no value column. It should still load.
+    const details = rescanned.tableDetails['hkworkoutactivitytyperunning'];
+    expect(details.error).toBeUndefined();
+    expect(details.primaryUnit).toBe('unknown');
+
+    const rows = await db.execute(`
+      SELECT duration, totalDistance
+      FROM hkworkoutactivitytyperunning
+      LIMIT 1
+    `);
+    expect(Number(rows[0].duration)).toBeGreaterThan(0);
+  });
 });

--- a/src/tools/health-schema.ts
+++ b/src/tools/health-schema.ts
@@ -14,6 +14,14 @@ export class HealthSchemaTool {
   }
   
   async execute(): Promise<any> {
+    // Pick up files exported after the server started. A failed rescan is not
+    // fatal, so fall back to the catalog we already have.
+    try {
+      await this.catalog.refresh();
+    } catch {
+      // keep the existing catalog
+    }
+
     // Get available tables from catalog
     const tableInfo = this.catalog.getTableInfo();
     const availableTables = Object.keys(tableInfo);
@@ -41,7 +49,6 @@ export class HealthSchemaTool {
     const schema: any = {
       summary: {
         totalTables: availableTables.length,
-        loadedTables: availableTables.filter(name => tableInfo[name].loaded).length,
         sampleTablesShown: sampleTables.length
       },
       availableTables: availableTables.sort(),
@@ -126,6 +133,10 @@ export class HealthSchemaTool {
       }
     }
     
+    const loadedNow = this.catalog.getTableInfo();
+    schema.summary.tablesInMemory = availableTables.filter(name => loadedNow[name]?.loaded).length;
+    schema.summary.loadingNote = 'Tables load into memory on demand. A low tablesInMemory count is normal. Every table in availableTables is queryable.';
+
     // Add common table patterns for reference
     schema.commonPatterns = {
       heartRate: availableTables.filter(t => t.includes('heartrate')),


### PR DESCRIPTION
## Summary

Second fix batch. Makes workout files discoverable and the catalog refreshable.

Fixes #12. Partial fix for #11 (workout data now catalogued and loadable; the workout report SQL lands in the next PR).

## Changes

- catalog regex also matches `HKWorkoutActivityType*.csv` (single-file and per-type exports)
- new `refresh()` rescans the data directory; `health_schema` calls it on each execute, so files exported after startup become queryable without a restart
- rescans keep loaded state for known tables
- `summary.loadedTables` (always 0, computed before loading) is replaced with `tablesInMemory`, computed after sample loading, plus a note that tables load on demand

## Tests

10 new tests (23 total): catalog matching and refresh behavior, plus an end-to-end check that a workout CSV written after the first `health_schema` call flows catalog → loader → schema and is queryable.
