### PR TITLE
load report tables on demand, fix sleep and workout queries

### DIFF
--- a/src/db/catalog.test.ts
+++ b/src/db/catalog.test.ts
@@ -79,6 +79,29 @@ describe('FileCatalog scanning', () => {
     );
   });
 
+  test('strips filename suffixes from the table name', async () => {
+    const suffixDir = mkdtempSync(join(tmpdir(), 'health-catalog-suffix-'));
+    writeCsv(
+      suffixDir,
+      'HKQuantityTypeIdentifierHeartRate_2026-07-212_11-19-16_SimpleHealthExportCSV.csv',
+      QUANTITY_HEADER,
+      [quantityRow()]
+    );
+    writeCsv(
+      suffixDir,
+      'HKWorkoutActivityTypeCycling_2026-07-212_11-19-21_SimpleHealthExportCSV.csv',
+      WORKOUT_HEADER,
+      [workoutRow('HKWorkoutActivityTypeCycling')]
+    );
+
+    const suffixCatalog = new FileCatalog(suffixDir);
+    await suffixCatalog.initialize();
+
+    expect(suffixCatalog.getAllTables()).toContain('hkquantitytypeidentifierheartrate');
+    expect(suffixCatalog.getAllTables()).toContain('hkworkoutactivitytypecycling');
+    rmSync(suffixDir, { recursive: true, force: true });
+  });
+
   test('ignores files that are not health exports', () => {
     const tables = catalog.getAllTables();
     expect(tables).not.toContain('notes');

--- a/src/db/catalog.ts
+++ b/src/db/catalog.ts
@@ -26,8 +26,11 @@ export class FileCatalog {
       for (const file of files) {
         // Workout exports are named HKWorkoutActivityType.csv or
         // HKWorkoutActivityTypeRunning.csv, with no literal "TypeIdentifier".
-        const match = file.match(/^(HK\w+TypeIdentifier\w+).*\.csv$/)
-          || file.match(/^(HKWorkoutActivityType\w*).*\.csv$/);
+        // The name capture stops at the first non-alphanumeric character, so a
+        // file like HKQuantityTypeIdentifierHeartRate_2026-07-21.csv still maps
+        // to the plain hkquantitytypeidentifierheartrate table name.
+        const match = file.match(/^(HK\w+?TypeIdentifier[A-Za-z0-9]+).*\.csv$/)
+          || file.match(/^(HKWorkoutActivityType[A-Za-z0-9]*).*\.csv$/);
         if (match) {
           const tableName = match[1].toLowerCase();
           const path = join(this.dataDir, file);

--- a/src/server.ts
+++ b/src/server.ts
@@ -47,7 +47,7 @@ const optimizer = new QueryOptimizer(loader);
 
 // Initialize tools
 const queryTool = new HealthQueryTool(db, cache, optimizer);
-const reportTool = new HealthReportTool(db, cache);
+const reportTool = new HealthReportTool(db, cache, catalog, loader);
 const schemaTool = new HealthSchemaTool(db, catalog, loader);
 
 // Create MCP server

--- a/src/tools/health-report.test.ts
+++ b/src/tools/health-report.test.ts
@@ -1,0 +1,234 @@
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { HealthDataDB } from '../db/database';
+import { FileCatalog } from '../db/catalog';
+import { TableLoader } from '../db/loader';
+import { QueryCache } from '../core/cache';
+import { HealthReportTool } from './health-report';
+
+const SLEEP_NIGHTS = 10;
+const ASLEEP_HOURS_PER_NIGHT = 8;
+const IN_BED_HOURS_PER_NIGHT = 9;
+const WORKOUT_MINUTES = 30;
+
+function formatTimestamp(date: Date): string {
+  return `${date.toISOString().slice(0, 19).replace('T', ' ')} +0000`;
+}
+
+function daysAgo(days: number): Date {
+  const date = new Date();
+  date.setDate(date.getDate() - days);
+  return date;
+}
+
+// Pin a time of day so every row for a night lands on the same calendar date.
+function dayAt(days: number, hours: number, minutes: number = 0): Date {
+  const date = daysAgo(days);
+  date.setUTCHours(hours, minutes, 0, 0);
+  return date;
+}
+
+function writeCsv(dir: string, fileName: string, header: string, rows: string[]): void {
+  const lines = ['sep=,', header, ...rows];
+  writeFileSync(join(dir, fileName), lines.join('\r\n') + '\r\n');
+}
+
+const QUANTITY_HEADER = 'type,sourceName,sourceVersion,productType,device,startDate,endDate,unit,value';
+const CATEGORY_HEADER = 'type,sourceName,sourceVersion,productType,device,startDate,endDate,value';
+const WORKOUT_HEADER = 'type,sourceName,sourceVersion,startDate,endDate,duration,totalEnergyBurned,totalDistance';
+
+function writeFixtures(dir: string, options: { heartRateOnly?: boolean } = {}): void {
+  const heartRateRows: string[] = [];
+  for (let day = 1; day <= 14; day++) {
+    for (let i = 0; i < 6; i++) {
+      const stamp = formatTimestamp(dayAt(day, 9 + i));
+      heartRateRows.push(
+        `HKQuantityTypeIdentifierHeartRate,Apple Watch,10.0,Watch7,1,${stamp},${stamp},count/min,${60 + i * 3}`
+      );
+    }
+  }
+  writeCsv(dir, 'HKQuantityTypeIdentifierHeartRate.csv', QUANTITY_HEADER, heartRateRows);
+
+  if (options.heartRateOnly) return;
+
+  // Each night: three asleep stages summing to 8 hours (00:30-08:30) plus an
+  // InBed row spanning 9 hours that the report must exclude.
+  const sleepRows: string[] = [];
+  for (let day = 1; day <= SLEEP_NIGHTS; day++) {
+    const stages: Array<[string, number, number]> = [
+      ['HKCategoryValueSleepAnalysisAsleepCore', 0, 4],
+      ['HKCategoryValueSleepAnalysisAsleepDeep', 4, 6],
+      ['HKCategoryValueSleepAnalysisAsleepREM', 6, 8]
+    ];
+    for (const [label, offsetStart, offsetEnd] of stages) {
+      const start = formatTimestamp(dayAt(day, 0, 30 + offsetStart * 60));
+      const end = formatTimestamp(dayAt(day, 0, 30 + offsetEnd * 60));
+      sleepRows.push(
+        `HKCategoryTypeIdentifierSleepAnalysis,Apple Watch,10.0,Watch7,1,${start},${end},${label}`
+      );
+    }
+    const inBedStart = formatTimestamp(dayAt(day, 0, 0));
+    const inBedEnd = formatTimestamp(dayAt(day, 0, IN_BED_HOURS_PER_NIGHT * 60));
+    sleepRows.push(
+      `HKCategoryTypeIdentifierSleepAnalysis,Apple Watch,10.0,Watch7,1,${inBedStart},${inBedEnd},HKCategoryValueSleepAnalysisInBed`
+    );
+  }
+  writeCsv(dir, 'HKCategoryTypeIdentifierSleepAnalysis.csv', CATEGORY_HEADER, sleepRows);
+
+  // Two per-type workout exports. The duration column holds minutes while the
+  // timestamps span WORKOUT_MINUTES minutes, so a report that trusts duration
+  // gets a wildly different total.
+  for (const [file, type] of [
+    ['HKWorkoutActivityTypeRunning.csv', 'HKWorkoutActivityTypeRunning'],
+    ['HKWorkoutActivityTypeCycling.csv', 'HKWorkoutActivityTypeCycling']
+  ]) {
+    const rows: string[] = [];
+    for (let day = 1; day <= 5; day++) {
+      const start = formatTimestamp(dayAt(day, 17));
+      const end = formatTimestamp(dayAt(day, 17, WORKOUT_MINUTES));
+      rows.push(`${type},Apple Watch,10.0,${start},${end},${WORKOUT_MINUTES},400,5.5`);
+    }
+    writeCsv(dir, file, WORKOUT_HEADER, rows);
+  }
+
+  const stepRows: string[] = [];
+  for (let day = 1; day <= 14; day++) {
+    const stamp = formatTimestamp(dayAt(day, 12));
+    stepRows.push(
+      `HKQuantityTypeIdentifierStepCount,iPhone,18.0,iPhone15,1,${stamp},${stamp},count,${8000 + day * 10}`
+    );
+  }
+  writeCsv(dir, 'HKQuantityTypeIdentifierStepCount.csv', QUANTITY_HEADER, stepRows);
+
+  const activeRows: string[] = [];
+  const basalRows: string[] = [];
+  for (let day = 1; day <= 14; day++) {
+    const stamp = formatTimestamp(dayAt(day, 13));
+    activeRows.push(
+      `HKQuantityTypeIdentifierActiveEnergyBurned,Apple Watch,10.0,Watch7,1,${stamp},${stamp},kcal,500`
+    );
+    basalRows.push(
+      `HKQuantityTypeIdentifierBasalEnergyBurned,Apple Watch,10.0,Watch7,1,${stamp},${stamp},kcal,1600`
+    );
+  }
+  writeCsv(dir, 'HKQuantityTypeIdentifierActiveEnergyBurned.csv', QUANTITY_HEADER, activeRows);
+  writeCsv(dir, 'HKQuantityTypeIdentifierBasalEnergyBurned.csv', QUANTITY_HEADER, basalRows);
+}
+
+function sectionByTitle(report: any, title: string): any {
+  return report.sections.find((section: any) => section.title === title);
+}
+
+let dataDir: string;
+let db: HealthDataDB;
+let report: any;
+
+beforeAll(async () => {
+  dataDir = mkdtempSync(join(tmpdir(), 'health-report-test-'));
+  writeFixtures(dataDir);
+
+  // Cold server: nothing loaded before the report runs.
+  db = new HealthDataDB({ dataDir, maxMemoryMB: 512 });
+  await db.initialize();
+  const catalog = new FileCatalog(dataDir);
+  await catalog.initialize();
+  const loader = new TableLoader(db, catalog);
+  const cache = new QueryCache(100);
+
+  const reportTool = new HealthReportTool(db, cache, catalog, loader);
+  report = await reportTool.execute({ report_type: 'weekly' });
+});
+
+afterAll(async () => {
+  await db.close();
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe('HealthReportTool on a cold server', () => {
+  test('returns every section without a prior query', () => {
+    const titles = report.sections.map((section: any) => section.title);
+    expect(titles).toEqual(['Heart Rate', 'Activity', 'Sleep', 'Workouts', 'Calories']);
+    expect(report.summary.length).toBeGreaterThan(0);
+  });
+
+  test('reports plausible heart rate numbers', () => {
+    const data = sectionByTitle(report, 'Heart Rate').data;
+    expect(Number(data.average)).toBeGreaterThan(50);
+    expect(Number(data.average)).toBeLessThan(120);
+    expect(Number(data.totalReadings)).toBeGreaterThan(0);
+    expect(Number(data.daysWithData)).toBe(7);
+  });
+
+  test('reports plausible activity numbers', () => {
+    const data = sectionByTitle(report, 'Activity').data;
+    expect(Number(data.activeDays)).toBe(7);
+    expect(Number(data.averageDailySteps)).toBeGreaterThan(1000);
+    expect(Number(data.totalSteps)).toBeGreaterThan(Number(data.averageDailySteps));
+  });
+
+  test('reports plausible calorie numbers', () => {
+    const data = sectionByTitle(report, 'Calories').data;
+    expect(Number(data.averageActiveCalories)).toBe(500);
+    expect(Number(data.averageBasalCalories)).toBe(1600);
+    expect(Number(data.averageTotalCalories)).toBe(2100);
+  });
+});
+
+describe('HealthReportTool sleep', () => {
+  test('sums asleep stage durations from timestamps', () => {
+    const data = sectionByTitle(report, 'Sleep').data;
+    expect(Number(data.averageHours)).toBeCloseTo(ASLEEP_HOURS_PER_NIGHT, 1);
+    expect(Number(data.nightsTracked)).toBe(7);
+  });
+
+  test('excludes InBed rows', () => {
+    const data = sectionByTitle(report, 'Sleep').data;
+    expect(Number(data.averageHours)).not.toBeCloseTo(IN_BED_HOURS_PER_NIGHT, 1);
+    expect(Number(data.maximumHours)).toBeCloseTo(ASLEEP_HOURS_PER_NIGHT, 1);
+  });
+});
+
+describe('HealthReportTool workouts', () => {
+  test('aggregates across every per-type workout table', () => {
+    const data = sectionByTitle(report, 'Workouts').data;
+    expect(Number(data.totalWorkouts)).toBe(10);
+    expect(Number(data.workoutTypes)).toBe(2);
+    expect(Number(data.totalCalories)).toBe(4000);
+  });
+
+  test('derives hours from timestamps, not the duration column', () => {
+    const data = sectionByTitle(report, 'Workouts').data;
+    const expectedHours = (10 * WORKOUT_MINUTES * 60) / 3600;
+    expect(Number(data.totalHours)).toBeCloseTo(expectedHours, 1);
+    // Reading the duration column as seconds would give 0.1 hours.
+    expect(Number(data.totalHours)).not.toBeCloseTo((10 * WORKOUT_MINUTES) / 3600, 1);
+  });
+});
+
+describe('HealthReportTool with a missing metric', () => {
+  test('says so instead of dropping the section', async () => {
+    const emptyDir = mkdtempSync(join(tmpdir(), 'health-report-empty-'));
+    writeFixtures(emptyDir, { heartRateOnly: true });
+
+    const emptyDb = new HealthDataDB({ dataDir: emptyDir, maxMemoryMB: 512 });
+    await emptyDb.initialize();
+    const catalog = new FileCatalog(emptyDir);
+    await catalog.initialize();
+    const loader = new TableLoader(emptyDb, catalog);
+    const reportTool = new HealthReportTool(emptyDb, new QueryCache(100), catalog, loader);
+
+    const result = await reportTool.execute({
+      report_type: 'weekly',
+      include_metrics: ['workouts']
+    });
+
+    expect(result.sections.length).toBe(1);
+    expect(result.sections[0].title).toBe('Workouts');
+    expect(result.sections[0].summary).toBe('No workouts data available');
+
+    await emptyDb.close();
+    rmSync(emptyDir, { recursive: true, force: true });
+  });
+});

--- a/src/tools/health-report.ts
+++ b/src/tools/health-report.ts
@@ -68,18 +68,22 @@ export class HealthReportTool {
     switch (type) {
       case 'weekly':
         const weekStart = new Date(now);
+        const weekEnd = new Date(now);
         weekStart.setDate(now.getDate() - 7);
+        weekEnd.setDate(now.getDate() - 1);
         return {
           start: weekStart.toISOString().split('T')[0],
-          end: now.toISOString().split('T')[0]
+          end: weekEnd.toISOString().split('T')[0]
         };
 
       case 'monthly':
         const monthStart = new Date(now);
+        const monthEnd = new Date(now);
         monthStart.setDate(now.getDate() - 30);
+        monthEnd.setDate(now.getDate() - 1);
         return {
           start: monthStart.toISOString().split('T')[0],
-          end: now.toISOString().split('T')[0]
+          end: monthEnd.toISOString().split('T')[0]
         };
 
       case 'custom':
@@ -193,6 +197,9 @@ export class HealthReportTool {
 
     const data = await this.runQuery(query);
     const [avgHr, minHr, maxHr, readings, days] = data.length ? data : [0, 0, 0, 0, 0];
+    if (Number(readings) === 0) {
+      return this.missingSection('Heart Rate', 'heart rate');
+    }
 
     return {
       title: 'Heart Rate',
@@ -232,6 +239,9 @@ export class HealthReportTool {
 
     const data = await this.runQuery(query);
     const [avgSteps, totalSteps, activeDays] = data.length ? data : [0, 0, 0];
+    if (Number(activeDays) === 0) {
+      return this.missingSection('Activity', 'activity');
+    }
 
     return {
       title: 'Activity',
@@ -275,6 +285,9 @@ export class HealthReportTool {
 
     const data = await this.runQuery(query);
     const [avgSleep, minSleep, maxSleep, nights] = data.length ? data : [0, 0, 0, 0];
+    if (Number(nights) === 0) {
+      return this.missingSection('Sleep', 'sleep');
+    }
 
     return {
       title: 'Sleep',
@@ -308,7 +321,13 @@ export class HealthReportTool {
         columns.map((col: any) => String(col.column_name).toLowerCase())
       );
 
-      const typeExpr = columnNames.has('type') ? 'type' : `'${table}'`;
+      let typeExpr = `'${table}'`;
+      if (columnNames.has('type')) {
+        typeExpr = `COALESCE(type, ${typeExpr})`;
+      }
+      if (columnNames.has('activitytype')) {
+        typeExpr = `COALESCE(activityType, ${typeExpr})`;
+      }
       const energyExpr = columnNames.has('totalenergyburned')
         ? 'TRY_CAST(totalEnergyBurned AS DOUBLE)'
         : 'NULL';
@@ -336,6 +355,9 @@ export class HealthReportTool {
 
     const data = await this.runQuery(query);
     const [workouts, types, hours, calories] = data.length ? data : [0, 0, 0, null];
+    if (Number(workouts) === 0) {
+      return this.missingSection('Workouts', 'workouts');
+    }
 
     return {
       title: 'Workouts',
@@ -369,7 +391,8 @@ export class HealthReportTool {
       SELECT
         ROUND(AVG(active_cal), 0) as avg_active_calories,
         ROUND(AVG(basal_cal), 0) as avg_basal_calories,
-        ROUND(AVG(active_cal + basal_cal), 0) as avg_total_calories
+        ROUND(AVG(active_cal + basal_cal), 0) as avg_total_calories,
+        COUNT(*) as days_tracked
       FROM (
         SELECT
           DATE(startDate) as date,
@@ -381,7 +404,10 @@ export class HealthReportTool {
     `;
 
     const data = await this.runQuery(query);
-    const [avgActive, avgBasal, avgTotal] = data.length ? data : [0, 0, 0];
+    const [avgActive, avgBasal, avgTotal, daysTracked] = data.length ? data : [0, 0, 0, 0];
+    if (Number(daysTracked) === 0) {
+      return this.missingSection('Calories', 'calories');
+    }
 
     return {
       title: 'Calories',
@@ -415,7 +441,7 @@ export class HealthReportTool {
     const startDate = new Date(start);
     const endDate = new Date(end);
     const diffTime = Math.abs(endDate.getTime() - startDate.getTime());
-    return Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+    return Math.floor(diffTime / (1000 * 60 * 60 * 24)) + 1;
   }
 
   private generateOverallSummary(sections: ReportSection[]): string {

--- a/src/tools/health-report.ts
+++ b/src/tools/health-report.ts
@@ -1,5 +1,7 @@
 import type { HealthDataDB } from '../db/database';
 import type { QueryCache } from '../core/cache';
+import type { FileCatalog } from '../db/catalog';
+import type { TableLoader } from '../db/loader';
 import type { HealthReportArgs } from '../types';
 
 interface ReportSection {
@@ -11,24 +13,28 @@ interface ReportSection {
 export class HealthReportTool {
   private db: HealthDataDB;
   private cache: QueryCache;
-  
-  constructor(db: HealthDataDB, cache: QueryCache) {
+  private catalog: FileCatalog;
+  private loader: TableLoader;
+
+  constructor(db: HealthDataDB, cache: QueryCache, catalog: FileCatalog, loader: TableLoader) {
     this.db = db;
     this.cache = cache;
+    this.catalog = catalog;
+    this.loader = loader;
   }
-  
+
   async execute(args: HealthReportArgs): Promise<any> {
     const { report_type, start_date, end_date, include_metrics } = args;
-    
+
     // Determine date range
     const dateRange = this.getDateRange(report_type, start_date, end_date);
-    
+
     // Determine which metrics to include
     const metrics = include_metrics || this.getDefaultMetrics();
-    
+
     // Generate report sections
     const sections: ReportSection[] = [];
-    
+
     for (const metric of metrics) {
       try {
         const section = await this.generateSection(metric, dateRange);
@@ -37,7 +43,7 @@ export class HealthReportTool {
         console.error(`Failed to generate ${metric} section:`, error);
       }
     }
-    
+
     // Create final report
     return {
       title: this.getReportTitle(report_type, dateRange),
@@ -51,14 +57,14 @@ export class HealthReportTool {
       summary: this.generateOverallSummary(sections)
     };
   }
-  
+
   private getDateRange(
     type: 'weekly' | 'monthly' | 'custom',
     startDate?: string,
     endDate?: string
   ): { start: string; end: string } {
     const now = new Date();
-    
+
     switch (type) {
       case 'weekly':
         const weekStart = new Date(now);
@@ -67,7 +73,7 @@ export class HealthReportTool {
           start: weekStart.toISOString().split('T')[0],
           end: now.toISOString().split('T')[0]
         };
-        
+
       case 'monthly':
         const monthStart = new Date(now);
         monthStart.setDate(now.getDate() - 30);
@@ -75,7 +81,7 @@ export class HealthReportTool {
           start: monthStart.toISOString().split('T')[0],
           end: now.toISOString().split('T')[0]
         };
-        
+
       case 'custom':
         if (!startDate || !endDate) {
           throw new Error('Start and end dates required for custom reports');
@@ -83,7 +89,7 @@ export class HealthReportTool {
         return { start: startDate, end: endDate };
     }
   }
-  
+
   private getDefaultMetrics(): string[] {
     return [
       'heart_rate',
@@ -93,7 +99,59 @@ export class HealthReportTool {
       'calories'
     ];
   }
-  
+
+  // Tables load on demand, so a report on a cold server has to load what it
+  // needs before querying. Returns the tables that actually exist afterwards -
+  // the loader skips tables with no rows in the rolling window.
+  private async ensureTables(tableNames: string[]): Promise<string[]> {
+    const loaded: string[] = [];
+
+    for (const tableName of tableNames) {
+      if (!this.catalog.getEntry(tableName)) continue;
+
+      try {
+        await this.loader.ensureTableLoaded(tableName);
+      } catch {
+        continue;
+      }
+
+      if (this.catalog.getEntry(tableName)?.loaded) {
+        loaded.push(tableName);
+      }
+    }
+
+    return loaded;
+  }
+
+  private getWorkoutTables(): string[] {
+    return this.catalog.getAllTables().filter(name => name.startsWith('hkworkoutactivitytype'));
+  }
+
+  private missingSection(title: string, metricLabel: string): ReportSection {
+    return {
+      title,
+      data: {},
+      summary: `No ${metricLabel} data available`
+    };
+  }
+
+  private async runQuery(query: string): Promise<any[]> {
+    const result = await this.cache.getOrExecute(
+      query,
+      async () => {
+        const rows = await this.db.execute(query);
+        return {
+          columns: Object.keys(rows[0] || {}),
+          rows: rows.map(row => Object.values(row)),
+          rowCount: rows.length,
+          executionTime: 0
+        };
+      }
+    );
+
+    return result.rows[0] || [];
+  }
+
   private async generateSection(
     metric: string,
     dateRange: { start: string; end: string }
@@ -113,12 +171,17 @@ export class HealthReportTool {
         return null;
     }
   }
-  
+
   private async generateHeartRateSection(
     dateRange: { start: string; end: string }
   ): Promise<ReportSection> {
+    const tables = await this.ensureTables(['hkquantitytypeidentifierheartrate']);
+    if (tables.length === 0) {
+      return this.missingSection('Heart Rate', 'heart rate');
+    }
+
     const query = `
-      SELECT 
+      SELECT
         ROUND(AVG(value), 1) as avg_hr,
         ROUND(MIN(value), 1) as min_hr,
         ROUND(MAX(value), 1) as max_hr,
@@ -127,23 +190,10 @@ export class HealthReportTool {
       FROM hkquantitytypeidentifierheartrate
       WHERE DATE(startDate) BETWEEN '${dateRange.start}' AND '${dateRange.end}'
     `;
-    
-    const result = await this.cache.getOrExecute(
-      query,
-      async () => {
-        const rows = await this.db.execute(query);
-        return {
-          columns: Object.keys(rows[0] || {}),
-          rows: rows.map(row => Object.values(row)),
-          rowCount: rows.length,
-          executionTime: 0
-        };
-      }
-    );
-    
-    const data = result.rows[0];
-    const [avgHr, minHr, maxHr, readings, days] = data || [0, 0, 0, 0, 0];
-    
+
+    const data = await this.runQuery(query);
+    const [avgHr, minHr, maxHr, readings, days] = data.length ? data : [0, 0, 0, 0, 0];
+
     return {
       title: 'Heart Rate',
       data: {
@@ -156,17 +206,22 @@ export class HealthReportTool {
       summary: `Average heart rate: ${avgHr} bpm (${minHr}-${maxHr} bpm) across ${days} days`
     };
   }
-  
+
   private async generateActivitySection(
     dateRange: { start: string; end: string }
   ): Promise<ReportSection> {
+    const tables = await this.ensureTables(['hkquantitytypeidentifierstepcount']);
+    if (tables.length === 0) {
+      return this.missingSection('Activity', 'activity');
+    }
+
     const query = `
-      SELECT 
+      SELECT
         ROUND(AVG(daily_steps), 0) as avg_daily_steps,
         ROUND(SUM(daily_steps), 0) as total_steps,
         COUNT(*) as active_days
       FROM (
-        SELECT 
+        SELECT
           DATE(startDate) as date,
           SUM(value) as daily_steps
         FROM hkquantitytypeidentifierstepcount
@@ -174,23 +229,10 @@ export class HealthReportTool {
         GROUP BY DATE(startDate)
       )
     `;
-    
-    const result = await this.cache.getOrExecute(
-      query,
-      async () => {
-        const rows = await this.db.execute(query);
-        return {
-          columns: Object.keys(rows[0] || {}),
-          rows: rows.map(row => Object.values(row)),
-          rowCount: rows.length,
-          executionTime: 0
-        };
-      }
-    );
-    
-    const data = result.rows[0];
-    const [avgSteps, totalSteps, activeDays] = data || [0, 0, 0];
-    
+
+    const data = await this.runQuery(query);
+    const [avgSteps, totalSteps, activeDays] = data.length ? data : [0, 0, 0];
+
     return {
       title: 'Activity',
       data: {
@@ -198,46 +240,42 @@ export class HealthReportTool {
         totalSteps: totalSteps,
         activeDays: activeDays
       },
-      summary: `Average ${avgSteps.toLocaleString()} steps/day (${totalSteps.toLocaleString()} total)`
+      summary: `Average ${Number(avgSteps ?? 0).toLocaleString()} steps/day (${Number(totalSteps ?? 0).toLocaleString()} total)`
     };
   }
-  
+
   private async generateSleepSection(
     dateRange: { start: string; end: string }
   ): Promise<ReportSection> {
+    const tables = await this.ensureTables(['hkcategorytypeidentifiersleepanalysis']);
+    if (tables.length === 0) {
+      return this.missingSection('Sleep', 'sleep');
+    }
+
+    // The stage lives in the value label, not in type, and the duration has to
+    // come from the timestamps - a category value is a label, not seconds.
+    // Matching '%asleep%' covers both HKCategoryValueSleepAnalysisAsleepCore and
+    // the bare asleepCore style, and excludes InBed and Awake rows.
     const query = `
-      SELECT 
+      SELECT
         ROUND(AVG(total_hours), 1) as avg_sleep_hours,
         ROUND(MIN(total_hours), 1) as min_sleep_hours,
         ROUND(MAX(total_hours), 1) as max_sleep_hours,
         COUNT(*) as nights_tracked
       FROM (
-        SELECT 
+        SELECT
           DATE(startDate) as night,
-          SUM(value) / 3600 as total_hours
+          SUM(DATE_DIFF('second', startDate, endDate)) / 3600.0 as total_hours
         FROM hkcategorytypeidentifiersleepanalysis
-        WHERE type LIKE '%Asleep%'
+        WHERE LOWER(valueText) LIKE '%asleep%'
           AND DATE(startDate) BETWEEN '${dateRange.start}' AND '${dateRange.end}'
         GROUP BY DATE(startDate)
       )
     `;
-    
-    const result = await this.cache.getOrExecute(
-      query,
-      async () => {
-        const rows = await this.db.execute(query);
-        return {
-          columns: Object.keys(rows[0] || {}),
-          rows: rows.map(row => Object.values(row)),
-          rowCount: rows.length,
-          executionTime: 0
-        };
-      }
-    );
-    
-    const data = result.rows[0];
-    const [avgSleep, minSleep, maxSleep, nights] = data || [0, 0, 0, 0];
-    
+
+    const data = await this.runQuery(query);
+    const [avgSleep, minSleep, maxSleep, nights] = data.length ? data : [0, 0, 0, 0];
+
     return {
       title: 'Sleep',
       data: {
@@ -249,36 +287,56 @@ export class HealthReportTool {
       summary: `Average ${avgSleep} hours/night across ${nights} nights`
     };
   }
-  
+
   private async generateWorkoutSection(
     dateRange: { start: string; end: string }
   ): Promise<ReportSection> {
+    // Workouts may be exported as one table or as one table per activity type.
+    const tables = await this.ensureTables(this.getWorkoutTables());
+    if (tables.length === 0) {
+      return this.missingSection('Workouts', 'workouts');
+    }
+
+    const selects: string[] = [];
+    for (const table of tables) {
+      const columns = await this.db.execute(`
+        SELECT column_name
+        FROM information_schema.columns
+        WHERE table_name = '${table}'
+      `);
+      const columnNames = new Set(
+        columns.map((col: any) => String(col.column_name).toLowerCase())
+      );
+
+      const typeExpr = columnNames.has('type') ? 'type' : `'${table}'`;
+      const energyExpr = columnNames.has('totalenergyburned')
+        ? 'TRY_CAST(totalEnergyBurned AS DOUBLE)'
+        : 'NULL';
+
+      // Duration comes from the timestamps. The exported duration column is
+      // minutes in some formats and seconds in others, so it cannot be trusted.
+      selects.push(`
+        SELECT
+          ${typeExpr} as workout_type,
+          DATE_DIFF('second', startDate, endDate) as duration_seconds,
+          ${energyExpr} as energy
+        FROM ${table}
+        WHERE DATE(startDate) BETWEEN '${dateRange.start}' AND '${dateRange.end}'
+      `);
+    }
+
     const query = `
-      SELECT 
+      SELECT
         COUNT(*) as total_workouts,
-        COUNT(DISTINCT activityType) as workout_types,
-        ROUND(SUM(duration) / 3600, 1) as total_hours,
-        ROUND(SUM(totalEnergyBurned), 0) as total_calories
-      FROM hkworkoutactivitytype
-      WHERE DATE(startDate) BETWEEN '${dateRange.start}' AND '${dateRange.end}'
+        COUNT(DISTINCT workout_type) as workout_types,
+        ROUND(SUM(duration_seconds) / 3600.0, 1) as total_hours,
+        ROUND(SUM(energy), 0) as total_calories
+      FROM (${selects.join('\n        UNION ALL\n')})
     `;
-    
-    const result = await this.cache.getOrExecute(
-      query,
-      async () => {
-        const rows = await this.db.execute(query);
-        return {
-          columns: Object.keys(rows[0] || {}),
-          rows: rows.map(row => Object.values(row)),
-          rowCount: rows.length,
-          executionTime: 0
-        };
-      }
-    );
-    
-    const data = result.rows[0];
-    const [workouts, types, hours, calories] = data || [0, 0, 0, 0];
-    
+
+    const data = await this.runQuery(query);
+    const [workouts, types, hours, calories] = data.length ? data : [0, 0, 0, null];
+
     return {
       title: 'Workouts',
       data: {
@@ -290,47 +348,41 @@ export class HealthReportTool {
       summary: `${workouts} workouts (${types} types) totaling ${hours} hours`
     };
   }
-  
+
   private async generateCaloriesSection(
     dateRange: { start: string; end: string }
   ): Promise<ReportSection> {
+    const tables = await this.ensureTables([
+      'hkquantitytypeidentifieractiveenergyburned',
+      'hkquantitytypeidentifierbasalenergyburned'
+    ]);
+    if (tables.length === 0) {
+      return this.missingSection('Calories', 'calories');
+    }
+
+    const sources = tables.map(table => `
+          SELECT type, startDate, value FROM ${table}
+          WHERE DATE(startDate) BETWEEN '${dateRange.start}' AND '${dateRange.end}'
+    `);
+
     const query = `
-      SELECT 
+      SELECT
         ROUND(AVG(active_cal), 0) as avg_active_calories,
         ROUND(AVG(basal_cal), 0) as avg_basal_calories,
         ROUND(AVG(active_cal + basal_cal), 0) as avg_total_calories
       FROM (
-        SELECT 
+        SELECT
           DATE(startDate) as date,
           SUM(CASE WHEN type LIKE '%ActiveEnergyBurned%' THEN value ELSE 0 END) as active_cal,
           SUM(CASE WHEN type LIKE '%BasalEnergyBurned%' THEN value ELSE 0 END) as basal_cal
-        FROM (
-          SELECT * FROM hkquantitytypeidentifieractiveenergyburned
-          WHERE DATE(startDate) BETWEEN '${dateRange.start}' AND '${dateRange.end}'
-          UNION ALL
-          SELECT * FROM hkquantitytypeidentifierbasalenergyburned
-          WHERE DATE(startDate) BETWEEN '${dateRange.start}' AND '${dateRange.end}'
-        )
+        FROM (${sources.join('\n          UNION ALL\n')})
         GROUP BY DATE(startDate)
       )
     `;
-    
-    const result = await this.cache.getOrExecute(
-      query,
-      async () => {
-        const rows = await this.db.execute(query);
-        return {
-          columns: Object.keys(rows[0] || {}),
-          rows: rows.map(row => Object.values(row)),
-          rowCount: rows.length,
-          executionTime: 0
-        };
-      }
-    );
-    
-    const data = result.rows[0];
-    const [avgActive, avgBasal, avgTotal] = data || [0, 0, 0];
-    
+
+    const data = await this.runQuery(query);
+    const [avgActive, avgBasal, avgTotal] = data.length ? data : [0, 0, 0];
+
     return {
       title: 'Calories',
       data: {
@@ -341,14 +393,14 @@ export class HealthReportTool {
       summary: `Average ${avgTotal} calories/day (${avgActive} active + ${avgBasal} basal)`
     };
   }
-  
+
   private getReportTitle(
     type: 'weekly' | 'monthly' | 'custom',
     dateRange: { start: string; end: string }
   ): string {
     const start = new Date(dateRange.start).toLocaleDateString();
     const end = new Date(dateRange.end).toLocaleDateString();
-    
+
     switch (type) {
       case 'weekly':
         return `Weekly Health Report (${start} - ${end})`;
@@ -358,14 +410,14 @@ export class HealthReportTool {
         return `Health Report (${start} - ${end})`;
     }
   }
-  
+
   private daysBetween(start: string, end: string): number {
     const startDate = new Date(start);
     const endDate = new Date(end);
     const diffTime = Math.abs(endDate.getTime() - startDate.getTime());
     return Math.ceil(diffTime / (1000 * 60 * 60 * 24));
   }
-  
+
   private generateOverallSummary(sections: ReportSection[]): string {
     const summaries = sections.map(s => s.summary).filter(s => s);
     return summaries.join('. ');

--- a/src/tools/health-report.ts
+++ b/src/tools/health-report.ts
@@ -424,8 +424,11 @@ export class HealthReportTool {
     type: 'weekly' | 'monthly' | 'custom',
     dateRange: { start: string; end: string }
   ): string {
-    const start = new Date(dateRange.start).toLocaleDateString();
-    const end = new Date(dateRange.end).toLocaleDateString();
+    // Date-only strings parse at UTC midnight. Format them in UTC as well so
+    // local time zones west of Greenwich do not display the previous day.
+    const dateFormatOptions: Intl.DateTimeFormatOptions = { timeZone: 'UTC' };
+    const start = new Date(dateRange.start).toLocaleDateString(undefined, dateFormatOptions);
+    const end = new Date(dateRange.end).toLocaleDateString(undefined, dateFormatOptions);
 
     switch (type) {
       case 'weekly':


### PR DESCRIPTION
## Summary

Third fix batch. This PR makes `health_report` correct on a cold server and on real exports.

Fixes #9, fixes #10, fixes #11.

## Changes

- The report tool now loads the tables that each section needs. A cold server returns a full report.
- Sections with no data in the period say "No <metric> data available". Before, the report dropped them.
- The sleep query reads the stage from `valueText` and gets hours from the timestamps. It does not count `InBed` rows.
- The workout query reads all workout tables. It takes the activity from `activityType`, then `type`, then the table name. It gets duration from the timestamps because the exported duration unit is not stable across formats.
- Table names stop at the first filename suffix. Real exports append a date suffix to each filename, which broke all table lookups.
- Weekly and monthly reports cover complete days and end yesterday.
- Report titles show the same dates in all time zones.

## Tests

10 new tests (33 total): cold-server report, sleep stage math, `InBed` exclusion, multi-table workout aggregation, and the missing-metric case.
