### PR TITLE
Allow duckdb build script under pnpm 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,9 @@
   "engines": {
     "node": ">=18.0.0"
   },
+  "pnpm": {
+    "onlyBuiltDependencies": ["duckdb"]
+  },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.4",
     "duckdb": "^1.1.3"


### PR DESCRIPTION
## Problem

pnpm 10 does not run the build scripts of dependencies by default. The duckdb install script does not run, so `duckdb.node` is missing and the server fails at start with `MODULE_NOT_FOUND`.

## Solution

Add `pnpm.onlyBuiltDependencies: ["duckdb"]` to `package.json`. This pre-approves the duckdb install script. npm and bun ignore this field.

Fixes #16