### PR TITLE
load full health history, remove the 90-day window

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,7 @@ build/
 *.db-journal
 HealthAll_*/
 health-data/
+data/
 tmp/
 mcp-server.log
+.worktrees/

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ the same command, arguments, environment, and `stdio` transport.
 | Variable | Required | Default | Purpose |
 | --- | --- | --- | --- |
 | `HEALTH_DATA_DIR` | Yes | — | Directory containing the exported CSV files |
-| `MAX_MEMORY_MB` | No | `1024` | DuckDB memory limit in megabytes |
+| `MAX_MEMORY_MB` | No | `2048` | DuckDB memory limit in megabytes |
 | `CACHE_SIZE` | No | `100` | Maximum number of cached query results |
 
 ## Export health data
@@ -68,18 +68,26 @@ Start with `health_schema`; table names depend on the files in your export.
 See [Querying Apple Health data](https://github.com/neiltron/apple-health-mcp/blob/main/docs/querying.md)
 for the data model and working examples.
 
-## Current limitation: 90-day window
+## History and memory
 
-When a table is first queried, the server currently loads only rows whose
-`startDate` is within the last 90 days. This is a hard-coded implementation
-limit, not a configurable query default. Older data remains in the CSV files
-but is unavailable to tools, and an older export may appear empty. Removing or
-making this behavior configurable is planned.
+The first request that needs a table loads that table's full CSV history. There
+is no date window, so a query can reach as far back as the export goes.
+
+Because every tool can reach the whole configured history, only start this
+server from an MCP client you trust with that data.
+
+Loaded tables are held in memory, and DuckDB is given the `MAX_MEMORY_MB` limit
+described above. Roughly 1 GiB covers a two-year multi-table export, so the
+2048MB default leaves headroom; raise `MAX_MEMORY_MB` for a larger export. The
+server never spills health rows to a temporary directory on disk, so an export
+that does not fit in the limit fails with an explicit error instead.
 
 Other current limitations:
 
 - Only the Simple Health Export CSV layout is supported.
-- The DuckDB database is in memory and is rebuilt for each server process.
+- The DuckDB database is in memory and is rebuilt for each server process, so
+  each launch reloads from the CSV files. Persistent incremental import is
+  planned future work, not current behavior.
 - Device overlap can produce duplicate-looking measurements; queries should
   account for `sourceName` where appropriate.
 - Health reports summarize recorded data and are not medical advice.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -57,22 +57,34 @@ ten-minute TTL. For non-aggregate queries, requests involving `CURRENT_DATE` or
 
 ### Memory management
 
-DuckDB receives the configured memory limit. A periodic manager also estimates
-loaded-table memory from row counts and evicts least-recently-used tables under
-pressure. This estimate is approximate.
+DuckDB receives the configured memory limit, which defaults to 2048MB and is
+overridden by `MAX_MEMORY_MB`. A two-year multi-table export holds roughly
+1 GiB resident, so the default leaves headroom for loading full history.
 
-## The rolling window
+`max_temp_directory_size` is set to `0 bytes`. DuckDB therefore cannot spill to
+a temporary directory, which keeps health rows out of files on disk and turns an
+over-capacity load into an explicit error instead of silent disk use.
 
-Every CSV load currently filters `startDate` against a cutoff computed as 90
-days before the current date. This filter was introduced as a resource-control
-shortcut, but it makes legitimate historical queries impossible and can make
-old exports appear empty. It is hard-coded in the active `TableLoader`
-constructor and is not currently configurable from the server.
+A periodic manager also estimates loaded-table memory from row counts and evicts
+least-recently-used tables under pressure. This estimate is approximate.
 
-The local roadmap tracks an investigation into replacing this behavior. Any
-change should measure startup/query cost with representative exports and decide
-whether the right default is full history, a configurable window, or persistent
-incremental import.
+## History loading
+
+A table's first request loads its full CSV history. There is no date window, so
+the rows a query can reach are limited only by the export itself. A row is
+excluded only when its `startDate` cannot be cast to a timestamp, or when the
+file shape has a `value` column and that value is null.
+
+The load is a single pass: one `CREATE TABLE AS SELECT` reads the CSV straight
+into the typed final table. `TableLoader` sniffs the file's columns with
+`DESCRIBE` first, which samples rather than materializes, so the projection
+matches the quantity, category, or workout shape it was given. Staging raw
+VARCHAR rows in a separate table beforehand would hold two copies resident and
+roughly double peak memory for a large export.
+
+A failed load drops the partially created table and raises. The failure
+propagates to the calling tool rather than leaving an empty table that looks
+like an export with no data.
 
 ## Transport constraints
 
@@ -84,7 +96,8 @@ MCP client and are subject to that client's data handling.
 ## Current boundaries
 
 - Simple Health Export CSV is the only ingest format.
-- The database is in memory; there is no incremental or persistent import.
+- The database is in memory and is rebuilt per process; incremental or
+  persistent import is planned future work.
 - Query validation and lazy-load table detection are string-based.
 - The implementation exposes tools only—no resources, prompts, HTTP transport,
   or hosted service.

--- a/docs/querying.md
+++ b/docs/querying.md
@@ -121,9 +121,14 @@ require `start_date` and `end_date` in `YYYY-MM-DD` form. Optional
 `include_metrics` values are `heart_rate`, `activity`, `sleep`, `workouts`, and
 `calories`.
 
-## Current data window
+## Available history
 
-Only records from the last 90 days are loaded at present, even if the CSV files
-contain older history. This is a server limitation rather than a SQL filter;
-removing a date predicate from a query does not expose older rows. The behavior
-is under review.
+The first query that touches a table loads that table's full CSV history, so
+the range a query can reach is whatever the export contains. The date
+predicates in the examples above are query filters you can widen or drop; the
+server adds no window of its own.
+
+A row is omitted only when its `startDate` cannot be parsed as a timestamp, or
+when the file has a `value` column and that row's value is empty. Loaded tables
+live in memory for the life of the server process, bounded by `MAX_MEMORY_MB`
+(2048MB by default); a very large export may need that raised.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neiltron/apple-health-mcp",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "mcpName": "io.github.neiltron/apple-health-mcp",
   "description": "MCP server for querying Apple Health data with DuckDB",
   "main": "dist/server.js",

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/neiltron/apple-health-mcp",
     "source": "github"
   },
-  "version": "1.2.1",
+  "version": "1.3.0",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@neiltron/apple-health-mcp",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"
@@ -30,7 +30,7 @@
           "name": "MAX_MEMORY_MB",
           "description": "Maximum memory usage in megabytes",
           "format": "number",
-          "default": "1024"
+          "default": "2048"
         },
         {
           "name": "CACHE_SIZE",

--- a/src/core/memory.ts
+++ b/src/core/memory.ts
@@ -14,7 +14,7 @@ export class MemoryManager {
     db: HealthDataDB, 
     catalog: FileCatalog, 
     loader: TableLoader,
-    maxMemoryMB: number = 1024
+    maxMemoryMB: number = 2048
   ) {
     this.db = db;
     this.catalog = catalog;

--- a/src/db/database.test.ts
+++ b/src/db/database.test.ts
@@ -31,4 +31,21 @@ describe('HealthDataDB settings', () => {
     expect(limitMiB).toBeGreaterThan(MAX_MEMORY_MB * 0.9);
     expect(limitMiB).toBeLessThanOrEqual(MAX_MEMORY_MB);
   });
+
+  test('defaults the memory limit to 2048MB', async () => {
+    const defaultDb = new HealthDataDB({ dataDir: '/nonexistent' });
+    await defaultDb.initialize();
+    try {
+      const result = await defaultDb.execute(
+        `SELECT current_setting('memory_limit') as memory_limit`
+      );
+      // DuckDB renders 2048MB as "1.9 GiB".
+      const setting = String(result[0].memory_limit);
+      expect(setting.endsWith('GiB')).toBe(true);
+      expect(parseFloat(setting)).toBeGreaterThanOrEqual(1.9);
+      expect(parseFloat(setting)).toBeLessThanOrEqual(2.0);
+    } finally {
+      await defaultDb.close();
+    }
+  });
 });

--- a/src/db/database.test.ts
+++ b/src/db/database.test.ts
@@ -1,0 +1,34 @@
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { HealthDataDB } from './database';
+
+const MAX_MEMORY_MB = 512;
+
+let db: HealthDataDB;
+
+beforeAll(async () => {
+  db = new HealthDataDB({ dataDir: '/nonexistent', maxMemoryMB: MAX_MEMORY_MB });
+  await db.initialize();
+});
+
+afterAll(async () => {
+  await db.close();
+});
+
+describe('HealthDataDB settings', () => {
+  test('gives the temporary directory zero capacity so health rows cannot spill to disk', async () => {
+    const result = await db.execute(
+      `SELECT current_setting('max_temp_directory_size') as max_temp_directory_size`
+    );
+    expect(String(result[0].max_temp_directory_size)).toBe('0 bytes');
+  });
+
+  test('applies the configured memory limit', async () => {
+    const result = await db.execute(
+      `SELECT current_setting('memory_limit') as memory_limit`
+    );
+    // DuckDB reports the limit in MiB, slightly below the requested MB value.
+    const limitMiB = parseFloat(String(result[0].memory_limit));
+    expect(limitMiB).toBeGreaterThan(MAX_MEMORY_MB * 0.9);
+    expect(limitMiB).toBeLessThanOrEqual(MAX_MEMORY_MB);
+  });
+});

--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -12,7 +12,10 @@ export class HealthDataDB {
 
   constructor(config: HealthDataConfig) {
     this.config = {
-      maxMemoryMB: 1024,
+      // A two-year multi-table export holds roughly 1 GiB resident in DuckDB,
+      // so 2048MB leaves headroom for loading full history. MAX_MEMORY_MB
+      // remains the user override.
+      maxMemoryMB: 2048,
       prewarmCache: false,
       ...config
     };

--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -8,14 +8,12 @@ export class HealthDataDB {
   private config: HealthDataConfig & {
     maxMemoryMB: number;
     prewarmCache: boolean;
-    rollingWindowDays: number;
   };
-  
+
   constructor(config: HealthDataConfig) {
     this.config = {
       maxMemoryMB: 1024,
       prewarmCache: false,
-      rollingWindowDays: 90,
       ...config
     };
     
@@ -28,9 +26,12 @@ export class HealthDataDB {
   
   private async setupDatabase(): Promise<void> {
     return new Promise((resolve, reject) => {
+      // Zero temporary capacity keeps health rows in memory. A load that does
+      // not fit fails loudly instead of spilling personal data to disk.
       this.db.run(`
         SET memory_limit = '${this.config.maxMemoryMB}MB';
         SET threads = 4;
+        SET max_temp_directory_size = '0 bytes';
       `, (err) => {
         if (err) reject(err);
         else resolve();
@@ -74,14 +75,6 @@ export class HealthDataDB {
         else resolve();
       });
     });
-  }
-  
-  async getMemoryUsage(): Promise<number> {
-    const result = await this.execute(`
-      SELECT current_setting('memory_limit') as memory_limit,
-             current_setting('temp_directory_size') as temp_size
-    `);
-    return parseFloat(result[0]?.memory_limit || '0');
   }
   
   async close(): Promise<void> {

--- a/src/db/loader.test.ts
+++ b/src/db/loader.test.ts
@@ -221,6 +221,22 @@ describe('TableLoader quantity tables', () => {
   });
 });
 
+describe('TableLoader staging', () => {
+  test('materializes no staging table for any loaded shape', async () => {
+    await loader.ensureTableLoaded('hkquantitytypeidentifierheartrate');
+    await loader.ensureTableLoaded('hkcategorytypeidentifiersleepanalysis');
+    await loader.ensureTableLoaded('hkworkouttypeidentifiertest');
+    await loader.ensureTableLoaded('hkquantitytypeidentifierrespiratoryrate');
+
+    const leftovers = await db.execute(`
+      SELECT table_name
+      FROM information_schema.tables
+      WHERE table_name LIKE '%_staging'
+    `);
+    expect(leftovers.length).toBe(0);
+  });
+});
+
 describe('TableLoader category tables', () => {
   test('keeps every row including old sleep stages', async () => {
     await loader.ensureTableLoaded('hkcategorytypeidentifiersleepanalysis');

--- a/src/db/loader.test.ts
+++ b/src/db/loader.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { HealthDataDB } from './database';
@@ -10,9 +10,11 @@ const RECENT_ROWS = 120;
 const OLD_ROWS = 5;
 const TOTAL_HEART_RATE_ROWS = RECENT_ROWS + OLD_ROWS;
 
-// Fixed historical anchors keep every assertion independent of the current date.
+// Fixed historical anchors keep every assertion independent of the current
+// date. The old anchor sits decades back so even a generous re-added
+// wall-clock window would fail these tests, not just a 90-day one.
 const RECENT_ANCHOR = new Date('2020-06-01T00:00:00Z');
-const OLD_ANCHOR = new Date('2019-01-15T00:00:00Z');
+const OLD_ANCHOR = new Date('2010-01-15T00:00:00Z');
 
 function formatTimestamp(date: Date): string {
   return `${date.toISOString().slice(0, 19).replace('T', ' ')} +0000`;
@@ -152,6 +154,14 @@ beforeAll(async () => {
     ]
   );
 
+  // No startDate column at all: not a loadable health export shape
+  writeCsv(
+    dataDir,
+    'HKQuantityTypeIdentifierNoDates.csv',
+    'type,sourceName,unit,value',
+    ['HKQuantityTypeIdentifierNoDates,Manual,count,1']
+  );
+
   db = new HealthDataDB({ dataDir, maxMemoryMB: 512 });
   await db.initialize();
   catalog = new FileCatalog(dataDir);
@@ -177,7 +187,7 @@ describe('TableLoader quantity tables', () => {
       SELECT MIN(startDate) as earliest
       FROM hkquantitytypeidentifierheartrate
     `);
-    expect(new Date(oldest[0].earliest).getUTCFullYear()).toBe(2019);
+    expect(new Date(oldest[0].earliest).getUTCFullYear()).toBe(2010);
   });
 
   test('records the stored row count in the catalog', async () => {
@@ -249,7 +259,7 @@ describe('TableLoader category tables', () => {
     const oldStage = await db.execute(`
       SELECT valueText, value
       FROM hkcategorytypeidentifiersleepanalysis
-      WHERE startDate < TIMESTAMP '2019-06-01 00:00:00'
+      WHERE startDate < TIMESTAMP '2010-06-01 00:00:00'
       ORDER BY startDate
       LIMIT 1
     `);
@@ -299,7 +309,7 @@ describe('TableLoader old-only tables', () => {
       FROM hkquantitytypeidentifierstepcount
     `);
     expect(Number(rows[0].count)).toBe(12);
-    expect(new Date(rows[0].latest).getUTCFullYear()).toBe(2019);
+    expect(new Date(rows[0].latest).getUTCFullYear()).toBe(2010);
   });
 });
 
@@ -343,6 +353,55 @@ describe('TableLoader date validation', () => {
   });
 });
 
+describe('TableLoader shape validation', () => {
+  test('rejects a CSV without a startDate column and leaves no table behind', async () => {
+    await expect(
+      loader.ensureTableLoaded('hkquantitytypeidentifiernodates')
+    ).rejects.toThrow('no startDate column');
+
+    expect(catalog.getEntry('hkquantitytypeidentifiernodates')?.loaded).toBe(false);
+    const tables = await db.execute(`
+      SELECT table_name
+      FROM information_schema.tables
+      WHERE table_name = 'hkquantitytypeidentifiernodates'
+    `);
+    expect(tables.length).toBe(0);
+  });
+});
+
+describe('TableLoader path handling', () => {
+  test('loads from a directory whose name contains a quote', async () => {
+    const parent = mkdtempSync(join(tmpdir(), 'health-loader-quote-'));
+    const quotedDir = join(parent, "Neil's Health");
+    mkdirSync(quotedDir);
+    writeCsv(
+      quotedDir,
+      'HKQuantityTypeIdentifierBodyMass.csv',
+      QUANTITY_HEADER,
+      [
+        `HKQuantityTypeIdentifierBodyMass,Withings,1.0,Scale,1,${formatTimestamp(OLD_ANCHOR)},${formatTimestamp(OLD_ANCHOR)},kg,70`
+      ]
+    );
+
+    const quotedDb = new HealthDataDB({ dataDir: quotedDir, maxMemoryMB: 512 });
+    await quotedDb.initialize();
+    const quotedCatalog = new FileCatalog(quotedDir);
+    await quotedCatalog.initialize();
+    const quotedLoader = new TableLoader(quotedDb, quotedCatalog);
+
+    try {
+      await quotedLoader.ensureTableLoaded('hkquantitytypeidentifierbodymass');
+      const rows = await quotedDb.execute(
+        'SELECT COUNT(*) as count FROM hkquantitytypeidentifierbodymass'
+      );
+      expect(Number(rows[0].count)).toBe(1);
+    } finally {
+      await quotedDb.close();
+      rmSync(parent, { recursive: true, force: true });
+    }
+  });
+});
+
 describe('TableLoader workout tables', () => {
   test('loads without error and keeps workout columns queryable', async () => {
     await loader.ensureTableLoaded('hkworkouttypeidentifiertest');
@@ -370,5 +429,67 @@ describe('TableLoader workout tables', () => {
     const names = columns.map((col: any) => String(col.column_name).toLowerCase());
     expect(names).not.toContain('value');
     expect(names).not.toContain('valuetext');
+  });
+});
+
+// Kept last in the file: the rescan test corrupts a fixture CSV on disk.
+describe('TableLoader load mechanics', () => {
+  let spyDb: HealthDataDB;
+  let spyCatalog: FileCatalog;
+  let spyLoader: TableLoader;
+  const statements: string[] = [];
+
+  beforeAll(async () => {
+    spyDb = new HealthDataDB({ dataDir, maxMemoryMB: 512 });
+    await spyDb.initialize();
+    spyCatalog = new FileCatalog(dataDir);
+    await spyCatalog.initialize();
+    spyLoader = new TableLoader(spyDb, spyCatalog);
+
+    const originalRun = spyDb.run.bind(spyDb);
+    const originalExecute = spyDb.execute.bind(spyDb);
+    spyDb.run = (query: string, sessionId?: string) => {
+      statements.push(query);
+      return originalRun(query, sessionId);
+    };
+    spyDb.execute = (query: string, sessionId?: string) => {
+      statements.push(query);
+      return originalExecute(query, sessionId);
+    };
+  });
+
+  afterAll(async () => {
+    await spyDb.close();
+  });
+
+  test('loads in one pass: a single CREATE TABLE, no staging, no date literal', async () => {
+    statements.length = 0;
+    await spyLoader.ensureTableLoaded('hkquantitytypeidentifierheartrate');
+
+    const creates = statements.filter((sql) => /CREATE TABLE/i.test(sql));
+    expect(creates.length).toBe(1);
+    expect(creates[0]).toContain('read_csv');
+    expect(creates[0]).toContain('IS NOT NULL');
+    // No wall-clock window: the load never compares startDate to a literal.
+    expect(creates[0]).not.toMatch(/TIMESTAMP\)\s*[<>=]/);
+    expect(statements.some((sql) => /_staging/i.test(sql))).toBe(false);
+  });
+
+  test('does not rescan the CSV once a table is loaded', async () => {
+    await spyLoader.ensureTableLoaded('hkquantitytypeidentifierstepcount');
+    const before = await spyDb.execute(
+      'SELECT COUNT(*) as count FROM hkquantitytypeidentifierstepcount'
+    );
+
+    // A second call must be served from the loaded table. If it re-read the
+    // file, this corrupted content would error or change the count.
+    writeFileSync(join(dataDir, 'HKQuantityTypeIdentifierStepCount.csv'), 'garbage');
+    await spyLoader.ensureTableLoaded('hkquantitytypeidentifierstepcount');
+
+    const after = await spyDb.execute(
+      'SELECT COUNT(*) as count FROM hkquantitytypeidentifierstepcount'
+    );
+    expect(Number(after[0].count)).toBe(Number(before[0].count));
+    expect(Number(after[0].count)).toBe(12);
   });
 });

--- a/src/db/loader.test.ts
+++ b/src/db/loader.test.ts
@@ -154,6 +154,21 @@ beforeAll(async () => {
     ]
   );
 
+  // Withings-style shape: metadata columns whose header names contain spaces
+  const withingsRows: string[] = [];
+  for (let i = 0; i < 3; i++) {
+    const start = formatTimestamp(daysAfter(OLD_ANCHOR, i));
+    withingsRows.push(
+      `HKQuantityTypeIdentifierHeight,Withings,8070102,"iPhone17,1",1,${start},${start},cm,${180 + i},5.2.1,12345`
+    );
+  }
+  writeCsv(
+    dataDir,
+    'HKQuantityTypeIdentifierHeight.csv',
+    'type,sourceName,sourceVersion,productType,device,startDate,endDate,unit,value,Health Mate App Version,Withings User Identifier',
+    withingsRows
+  );
+
   // No startDate column at all: not a loadable health export shape
   writeCsv(
     dataDir,
@@ -366,6 +381,25 @@ describe('TableLoader shape validation', () => {
       WHERE table_name = 'hkquantitytypeidentifiernodates'
     `);
     expect(tables.length).toBe(0);
+  });
+});
+
+describe('TableLoader header handling', () => {
+  test('loads a CSV whose metadata column names contain spaces', async () => {
+    await loader.ensureTableLoaded('hkquantitytypeidentifierheight');
+
+    const entry = catalog.getEntry('hkquantitytypeidentifierheight');
+    expect(entry?.loaded).toBe(true);
+    expect(entry?.rowCount).toBe(3);
+
+    const rows = await db.execute(`
+      SELECT value, "Health Mate App Version" as appVersion
+      FROM hkquantitytypeidentifierheight
+      ORDER BY startDate
+      LIMIT 1
+    `);
+    expect(Number(rows[0].value)).toBe(180);
+    expect(String(rows[0].appVersion)).toBe('5.2.1');
   });
 });
 

--- a/src/db/loader.test.ts
+++ b/src/db/loader.test.ts
@@ -8,20 +8,34 @@ import { TableLoader } from './loader';
 
 const RECENT_ROWS = 120;
 const OLD_ROWS = 5;
+const TOTAL_HEART_RATE_ROWS = RECENT_ROWS + OLD_ROWS;
+
+// Fixed historical anchors keep every assertion independent of the current date.
+const RECENT_ANCHOR = new Date('2020-06-01T00:00:00Z');
+const OLD_ANCHOR = new Date('2019-01-15T00:00:00Z');
 
 function formatTimestamp(date: Date): string {
   return `${date.toISOString().slice(0, 19).replace('T', ' ')} +0000`;
 }
 
-function daysAgo(days: number): Date {
-  const date = new Date();
-  date.setDate(date.getDate() - days);
+function daysAfter(anchor: Date, days: number): Date {
+  const date = new Date(anchor);
+  date.setDate(date.getDate() + days);
   return date;
 }
 
 function writeCsv(dir: string, fileName: string, header: string, rows: string[]): void {
   const lines = ['sep=,', header, ...rows];
   writeFileSync(join(dir, fileName), lines.join('\r\n') + '\r\n');
+}
+
+const QUANTITY_HEADER =
+  'type,sourceName,sourceVersion,productType,device,startDate,endDate,unit,value';
+const CATEGORY_HEADER =
+  'type,sourceName,sourceVersion,productType,device,startDate,endDate,value';
+
+function quantityRow(start: string, value: number): string {
+  return `HKQuantityTypeIdentifierHeartRate,Apple Watch,10.0,Watch7,1,${start},${start},count/min,${value}`;
 }
 
 let dataDir: string;
@@ -35,21 +49,17 @@ beforeAll(async () => {
   // Quantity shape: has unit and numeric value
   const heartRateRows: string[] = [];
   for (let i = 0; i < RECENT_ROWS; i++) {
-    const start = formatTimestamp(daysAgo(1 + (i % 60)));
-    heartRateRows.push(
-      `HKQuantityTypeIdentifierHeartRate,Apple Watch,10.0,Watch7,1,${start},${start},count/min,${60 + (i % 40)}`
-    );
+    const start = formatTimestamp(daysAfter(RECENT_ANCHOR, i % 60));
+    heartRateRows.push(quantityRow(start, 60 + (i % 40)));
   }
   for (let i = 0; i < OLD_ROWS; i++) {
-    const start = formatTimestamp(daysAgo(200 + i));
-    heartRateRows.push(
-      `HKQuantityTypeIdentifierHeartRate,Apple Watch,10.0,Watch7,1,${start},${start},count/min,${50 + i}`
-    );
+    const start = formatTimestamp(daysAfter(OLD_ANCHOR, i));
+    heartRateRows.push(quantityRow(start, 50 + i));
   }
   writeCsv(
     dataDir,
     'HKQuantityTypeIdentifierHeartRate.csv',
-    'type,sourceName,sourceVersion,productType,device,startDate,endDate,unit,value',
+    QUANTITY_HEADER,
     heartRateRows
   );
 
@@ -62,28 +72,28 @@ beforeAll(async () => {
   ];
   const sleepRows: string[] = [];
   for (let i = 0; i < 40; i++) {
-    const start = formatTimestamp(daysAgo(1 + (i % 30)));
+    const start = formatTimestamp(daysAfter(RECENT_ANCHOR, i % 30));
     sleepRows.push(
       `HKCategoryTypeIdentifierSleepAnalysis,Apple Watch,10.0,Watch7,1,${start},${start},${stages[i % stages.length]}`
     );
   }
   for (let i = 0; i < OLD_ROWS; i++) {
-    const start = formatTimestamp(daysAgo(200 + i));
+    const start = formatTimestamp(daysAfter(OLD_ANCHOR, i));
     sleepRows.push(
-      `HKCategoryTypeIdentifierSleepAnalysis,Apple Watch,10.0,Watch7,1,${start},${start},${stages[0]}`
+      `HKCategoryTypeIdentifierSleepAnalysis,Apple Watch,10.0,Watch7,1,${start},${start},HKCategoryValueSleepAnalysisAsleepDeep`
     );
   }
   writeCsv(
     dataDir,
     'HKCategoryTypeIdentifierSleepAnalysis.csv',
-    'type,sourceName,sourceVersion,productType,device,startDate,endDate,value',
+    CATEGORY_HEADER,
     sleepRows
   );
 
   // Workout shape: no unit and no value column
   const workoutRows: string[] = [];
   for (let i = 0; i < 10; i++) {
-    const start = formatTimestamp(daysAgo(1 + i));
+    const start = formatTimestamp(daysAfter(RECENT_ANCHOR, i));
     workoutRows.push(
       `HKWorkoutActivityTypeRunning,Apple Watch,10.0,${start},${start},${1800 + i},${400 + i},${5.5 + i}`
     );
@@ -93,6 +103,53 @@ beforeAll(async () => {
     'HKWorkoutTypeIdentifierTest.csv',
     'type,sourceName,sourceVersion,startDate,endDate,duration,totalEnergyBurned,totalDistance',
     workoutRows
+  );
+
+  // Old-only shape: every row is years old
+  const oldOnlyRows: string[] = [];
+  for (let i = 0; i < 12; i++) {
+    const start = formatTimestamp(daysAfter(OLD_ANCHOR, i));
+    oldOnlyRows.push(
+      `HKQuantityTypeIdentifierStepCount,iPhone,10.0,iPhone12,1,${start},${start},count,${1000 + i}`
+    );
+  }
+  writeCsv(
+    dataDir,
+    'HKQuantityTypeIdentifierStepCount.csv',
+    'type,sourceName,sourceVersion,productType,device,startDate,endDate,unit,value',
+    oldOnlyRows
+  );
+
+  // Mixed validity: valid old rows plus rows with unparseable or missing startDate
+  const mixedRows: string[] = [];
+  for (let i = 0; i < 4; i++) {
+    const start = formatTimestamp(daysAfter(OLD_ANCHOR, i));
+    mixedRows.push(
+      `HKQuantityTypeIdentifierBodyMass,Withings,1.0,Scale,1,${start},${start},kg,${70 + i}`
+    );
+  }
+  mixedRows.push(
+    'HKQuantityTypeIdentifierBodyMass,Withings,1.0,Scale,1,not-a-date,not-a-date,kg,99'
+  );
+  mixedRows.push(
+    'HKQuantityTypeIdentifierBodyMass,Withings,1.0,Scale,1,,,kg,98'
+  );
+  writeCsv(
+    dataDir,
+    'HKQuantityTypeIdentifierBodyMass.csv',
+    'type,sourceName,sourceVersion,productType,device,startDate,endDate,unit,value',
+    mixedRows
+  );
+
+  // No survivable rows: every startDate is unparseable
+  writeCsv(
+    dataDir,
+    'HKQuantityTypeIdentifierRespiratoryRate.csv',
+    'type,sourceName,sourceVersion,productType,device,startDate,endDate,unit,value',
+    [
+      'HKQuantityTypeIdentifierRespiratoryRate,Apple Watch,10.0,Watch7,1,bad,bad,count/min,12',
+      'HKQuantityTypeIdentifierRespiratoryRate,Apple Watch,10.0,Watch7,1,also-bad,also-bad,count/min,13'
+    ]
   );
 
   db = new HealthDataDB({ dataDir, maxMemoryMB: 512 });
@@ -108,13 +165,27 @@ afterAll(async () => {
 });
 
 describe('TableLoader quantity tables', () => {
-  test('loads only rows inside the rolling window', async () => {
+  test('loads every row regardless of age', async () => {
     await loader.ensureTableLoaded('hkquantitytypeidentifierheartrate');
 
     const result = await db.execute(
       'SELECT COUNT(*) as count FROM hkquantitytypeidentifierheartrate'
     );
-    expect(Number(result[0].count)).toBe(RECENT_ROWS);
+    expect(Number(result[0].count)).toBe(TOTAL_HEART_RATE_ROWS);
+
+    const oldest = await db.execute(`
+      SELECT MIN(startDate) as earliest
+      FROM hkquantitytypeidentifierheartrate
+    `);
+    expect(new Date(oldest[0].earliest).getUTCFullYear()).toBe(2019);
+  });
+
+  test('records the stored row count in the catalog', async () => {
+    await loader.ensureTableLoaded('hkquantitytypeidentifierheartrate');
+
+    const entry = catalog.getEntry('hkquantitytypeidentifierheartrate');
+    expect(entry?.loaded).toBe(true);
+    expect(entry?.rowCount).toBe(TOTAL_HEART_RATE_ROWS);
   });
 
   test('keeps a numeric value, a valueText copy, and the unit', async () => {
@@ -136,29 +207,52 @@ describe('TableLoader quantity tables', () => {
     expect(Number(numeric[0].avg_value)).toBeGreaterThan(0);
   });
 
-  test('ensureTableLoaded is idempotent', async () => {
+  test('ensureTableLoaded is idempotent and preserves the full row count', async () => {
     await loader.ensureTableLoaded('hkquantitytypeidentifierheartrate');
     await loader.ensureTableLoaded('hkquantitytypeidentifierheartrate');
 
     const result = await db.execute(
       'SELECT COUNT(*) as count FROM hkquantitytypeidentifierheartrate'
     );
-    expect(Number(result[0].count)).toBe(RECENT_ROWS);
+    expect(Number(result[0].count)).toBe(TOTAL_HEART_RATE_ROWS);
+    expect(catalog.getEntry('hkquantitytypeidentifierheartrate')?.rowCount).toBe(
+      TOTAL_HEART_RATE_ROWS
+    );
   });
 });
 
 describe('TableLoader category tables', () => {
-  test('loads without error and preserves the stage label in valueText', async () => {
+  test('keeps every row including old sleep stages', async () => {
+    await loader.ensureTableLoaded('hkcategorytypeidentifiersleepanalysis');
+
+    const result = await db.execute(
+      'SELECT COUNT(*) as count FROM hkcategorytypeidentifiersleepanalysis'
+    );
+    expect(Number(result[0].count)).toBe(40 + OLD_ROWS);
+
+    const oldStage = await db.execute(`
+      SELECT valueText, value
+      FROM hkcategorytypeidentifiersleepanalysis
+      WHERE startDate < TIMESTAMP '2019-06-01 00:00:00'
+      ORDER BY startDate
+      LIMIT 1
+    `);
+    expect(oldStage.length).toBe(1);
+    expect(oldStage[0].valueText).toBe('HKCategoryValueSleepAnalysisAsleepDeep');
+    expect(oldStage[0].value).toBeNull();
+  });
+
+  test('preserves the stage label in valueText with a null numeric value', async () => {
     await loader.ensureTableLoaded('hkcategorytypeidentifiersleepanalysis');
 
     const rows = await db.execute(`
       SELECT valueText, value
       FROM hkcategorytypeidentifiersleepanalysis
-      WHERE valueText = 'HKCategoryValueSleepAnalysisAsleepDeep'
+      WHERE valueText = 'HKCategoryValueSleepAnalysisAsleepREM'
       LIMIT 1
     `);
     expect(rows.length).toBe(1);
-    expect(rows[0].valueText).toBe('HKCategoryValueSleepAnalysisAsleepDeep');
+    expect(rows[0].valueText).toBe('HKCategoryValueSleepAnalysisAsleepREM');
     expect(rows[0].value).toBeNull();
   });
 
@@ -173,6 +267,63 @@ describe('TableLoader category tables', () => {
     const names = columns.map((col: any) => String(col.column_name).toLowerCase());
     expect(names).not.toContain('unit');
     expect(names).toContain('valuetext');
+  });
+});
+
+describe('TableLoader old-only tables', () => {
+  test('marks the table loaded and returns the old rows', async () => {
+    await loader.ensureTableLoaded('hkquantitytypeidentifierstepcount');
+
+    const entry = catalog.getEntry('hkquantitytypeidentifierstepcount');
+    expect(entry?.loaded).toBe(true);
+    expect(entry?.rowCount).toBe(12);
+
+    const rows = await db.execute(`
+      SELECT COUNT(*) as count, MAX(startDate) as latest
+      FROM hkquantitytypeidentifierstepcount
+    `);
+    expect(Number(rows[0].count)).toBe(12);
+    expect(new Date(rows[0].latest).getUTCFullYear()).toBe(2019);
+  });
+});
+
+describe('TableLoader date validation', () => {
+  test('excludes rows with an invalid or missing startDate and keeps valid old rows', async () => {
+    await loader.ensureTableLoaded('hkquantitytypeidentifierbodymass');
+
+    const rows = await db.execute(`
+      SELECT COUNT(*) as count
+      FROM hkquantitytypeidentifierbodymass
+    `);
+    expect(Number(rows[0].count)).toBe(4);
+
+    const invalid = await db.execute(`
+      SELECT COUNT(*) as count
+      FROM hkquantitytypeidentifierbodymass
+      WHERE startDate IS NULL
+    `);
+    expect(Number(invalid[0].count)).toBe(0);
+    expect(catalog.getEntry('hkquantitytypeidentifierbodymass')?.rowCount).toBe(4);
+  });
+
+  test('marks a table with no surviving rows as loaded and queryable', async () => {
+    await loader.ensureTableLoaded('hkquantitytypeidentifierrespiratoryrate');
+
+    const entry = catalog.getEntry('hkquantitytypeidentifierrespiratoryrate');
+    expect(entry?.loaded).toBe(true);
+    expect(entry?.rowCount).toBe(0);
+
+    const rows = await db.execute(
+      'SELECT * FROM hkquantitytypeidentifierrespiratoryrate'
+    );
+    expect(rows.length).toBe(0);
+
+    // A second call must not rescan the CSV; the table stays present and empty.
+    await loader.ensureTableLoaded('hkquantitytypeidentifierrespiratoryrate');
+    const again = await db.execute(
+      'SELECT COUNT(*) as count FROM hkquantitytypeidentifierrespiratoryrate'
+    );
+    expect(Number(again[0].count)).toBe(0);
   });
 });
 

--- a/src/db/loader.ts
+++ b/src/db/loader.ts
@@ -25,68 +25,59 @@ export class TableLoader {
   }
   
   private async loadTable(tableName: string, filePath: string): Promise<void> {
-    const tempTableName = `${tableName}_staging`;
-    
     try {
-      // Stage every row whose startDate can become a timestamp. There is no
-      // history window; rows with an invalid or missing startDate are the only
-      // ones excluded.
-      await this.db.run(`
-        CREATE TABLE ${tempTableName} AS
-        SELECT * FROM read_csv('${filePath}',
-          header = true,
-          skip = 1,
-          delim = ',',
-          quote = '"',
-          escape = '"',
-          ignore_errors = true,
-          null_padding = true,
-          new_line = '\\r\\n'
-        )
-        WHERE TRY_CAST(SUBSTR(startDate, 1, 19) AS TIMESTAMP) IS NOT NULL
-      `);
+      await this.cleanAndOptimizeTable(filePath, tableName);
 
-      // A file with no readable rows still produces an empty final table so
-      // queries return zero rows instead of a missing-table error, and the CSV
-      // is not rescanned on every request.
-      await this.cleanAndOptimizeTable(tempTableName, tableName);
-
-      // Count the final table: cleanAndOptimizeTable also drops rows with a
-      // null value, so the catalog count matches what is actually stored.
+      // Count the final table: the load also drops rows with a null value, so
+      // the catalog count matches what is actually stored. A file with no
+      // readable rows still produces an empty table and is still marked loaded,
+      // so queries return zero rows instead of a missing-table error and the
+      // CSV is not rescanned on every request.
       const countResult = await this.db.execute(
         `SELECT COUNT(*) as count FROM ${tableName}`
       );
       const rowCount = Number(countResult[0]?.count ?? 0);
       this.catalog.markLoaded(tableName, rowCount);
     } catch (error) {
-      // Clean up on error
-      await this.db.run(`DROP TABLE IF EXISTS ${tempTableName}`);
+      // Clean up on error. There is no staging table, so the partially created
+      // final table is the only thing that can be left behind.
+      await this.db.run(`DROP TABLE IF EXISTS ${tableName}`);
       throw new Error(`Failed to load table ${tableName}: ${error}`);
     }
   }
-  
-  private async cleanAndOptimizeTable(stagingTable: string, finalTable: string): Promise<void> {
+
+  private csvSource(filePath: string): string {
+    return `read_csv('${filePath}',
+        header = true,
+        skip = 1,
+        delim = ',',
+        quote = '"',
+        escape = '"',
+        ignore_errors = true,
+        null_padding = true,
+        new_line = '\\r\\n'
+      )`;
+  }
+
+  private async cleanAndOptimizeTable(filePath: string, finalTable: string): Promise<void> {
     // Drop existing table if it exists
     await this.db.run(`DROP TABLE IF EXISTS ${finalTable}`);
 
+    const source = this.csvSource(filePath);
+
     // Health exports come in several shapes. Quantity CSVs have unit and value,
     // category CSVs have no unit, workout CSVs have neither and carry duration
-    // and energy columns instead. Build the projection from the columns that
-    // are actually present so every shape loads.
-    const stagingColumns = await this.db.execute(`
-      SELECT column_name
-      FROM information_schema.columns
-      WHERE table_name = '${stagingTable}'
-      ORDER BY ordinal_position
-    `);
-    const columnNames: string[] = stagingColumns.map((col: any) => col.column_name);
+    // and energy columns instead. Sniff the columns first so the projection is
+    // built from the columns that are actually present and every shape loads.
+    // DESCRIBE only samples the file; it materializes no rows.
+    const describedColumns = await this.db.execute(`DESCRIBE SELECT * FROM ${source}`);
+    const columnNames: string[] = describedColumns.map((col: any) => col.column_name);
     const columnByLower = new Map<string, string>();
     for (const name of columnNames) {
       columnByLower.set(name.toLowerCase(), name);
     }
 
     const startDateCol = columnByLower.get('startdate');
-    const endDateCol = columnByLower.get('enddate');
     const valueCol = columnByLower.get('value');
     const typeCol = columnByLower.get('type');
 
@@ -105,14 +96,28 @@ export class TableLoader {
       }
     }
 
-    const whereClause = valueCol ? `\n      WHERE ${valueCol} IS NOT NULL` : '';
+    // Keep every row whose startDate can become a timestamp. There is no
+    // history window; an invalid or missing startDate, and a null value where
+    // the shape has a value column, are the only exclusions.
+    const conditions: string[] = [];
+    if (startDateCol) {
+      conditions.push(`TRY_CAST(SUBSTR(${startDateCol}, 1, 19) AS TIMESTAMP) IS NOT NULL`);
+    }
+    if (valueCol) {
+      conditions.push(`${valueCol} IS NOT NULL`);
+    }
+    const whereClause = conditions.length
+      ? `\n      WHERE ${conditions.join('\n        AND ')}`
+      : '';
 
-    // Create optimized table with proper types and indexes
+    // One pass from CSV straight into the typed final table. Staging the raw
+    // rows first would hold both copies resident and roughly double peak memory
+    // for a large export.
     await this.db.run(`
       CREATE TABLE ${finalTable} AS
       SELECT
         ${selectParts.join(',\n        ')}
-      FROM ${stagingTable}${whereClause}
+      FROM ${source}${whereClause}
     `);
 
     // Create indexes for common query patterns
@@ -129,9 +134,6 @@ export class TableLoader {
         ON ${finalTable}(${typeCol})
       `);
     }
-
-    // Drop staging table
-    await this.db.run(`DROP TABLE ${stagingTable}`);
   }
   
   async loadAllTables(): Promise<void> {

--- a/src/db/loader.ts
+++ b/src/db/loader.ts
@@ -46,6 +46,13 @@ export class TableLoader {
     }
   }
 
+  // Column names come from CSV headers, and real exports contain metadata
+  // columns with spaces, e.g. "Health Mate App Version" from Withings. Every
+  // identifier taken from a header must be quoted.
+  private quoteIdent(name: string): string {
+    return `"${name.replace(/"/g, '""')}"`;
+  }
+
   private csvSource(filePath: string): string {
     // Paths are not user queries, but a directory name like "Neil's Health"
     // contains a quote that would end the SQL literal early.
@@ -94,15 +101,16 @@ export class TableLoader {
     const selectParts: string[] = [];
     for (const name of columnNames) {
       const lower = name.toLowerCase();
+      const ident = this.quoteIdent(name);
       if (lower === 'startdate' || lower === 'enddate') {
-        selectParts.push(`TRY_CAST(SUBSTR(${name}, 1, 19) AS TIMESTAMP) as ${name}`);
+        selectParts.push(`TRY_CAST(SUBSTR(${ident}, 1, 19) AS TIMESTAMP) as ${ident}`);
       } else if (lower === 'value') {
         // Category rows hold text labels like HKCategoryValueSleepAnalysisAsleepCore.
         // Keep the numeric cast for quantity queries and keep the raw label in valueText.
-        selectParts.push(`TRY_CAST(${name} AS DOUBLE) as ${name}`);
-        selectParts.push(`CAST(${name} AS VARCHAR) as valueText`);
+        selectParts.push(`TRY_CAST(${ident} AS DOUBLE) as ${ident}`);
+        selectParts.push(`CAST(${ident} AS VARCHAR) as valueText`);
       } else {
-        selectParts.push(name);
+        selectParts.push(ident);
       }
     }
 
@@ -110,10 +118,10 @@ export class TableLoader {
     // history window; an invalid startDate, and a null value where the shape
     // has a value column, are the only exclusions.
     const conditions: string[] = [
-      `TRY_CAST(SUBSTR(${startDateCol}, 1, 19) AS TIMESTAMP) IS NOT NULL`,
+      `TRY_CAST(SUBSTR(${this.quoteIdent(startDateCol)}, 1, 19) AS TIMESTAMP) IS NOT NULL`,
     ];
     if (valueCol) {
-      conditions.push(`${valueCol} IS NOT NULL`);
+      conditions.push(`${this.quoteIdent(valueCol)} IS NOT NULL`);
     }
     const whereClause = `\n      WHERE ${conditions.join('\n        AND ')}`;
 
@@ -130,13 +138,13 @@ export class TableLoader {
     // Create indexes for common query patterns
     await this.db.run(`
       CREATE INDEX IF NOT EXISTS idx_${finalTable}_startdate
-      ON ${finalTable}(${startDateCol})
+      ON ${finalTable}(${this.quoteIdent(startDateCol)})
     `);
 
     if (typeCol) {
       await this.db.run(`
         CREATE INDEX IF NOT EXISTS idx_${finalTable}_type
-        ON ${finalTable}(${typeCol})
+        ON ${finalTable}(${this.quoteIdent(typeCol)})
       `);
     }
   }

--- a/src/db/loader.ts
+++ b/src/db/loader.ts
@@ -4,12 +4,10 @@ import type { FileCatalog } from './catalog';
 export class TableLoader {
   private db: HealthDataDB;
   private catalog: FileCatalog;
-  private rollingWindowDays: number;
-  
-  constructor(db: HealthDataDB, catalog: FileCatalog, rollingWindowDays: number = 90) {
+
+  constructor(db: HealthDataDB, catalog: FileCatalog) {
     this.db = db;
     this.catalog = catalog;
-    this.rollingWindowDays = rollingWindowDays;
   }
   
   async ensureTableLoaded(tableName: string): Promise<void> {
@@ -30,13 +28,9 @@ export class TableLoader {
     const tempTableName = `${tableName}_staging`;
     
     try {
-      // console.log(`Loading table ${tableName} from ${filePath}`);
-      
-      // Create staging table with recent data only
-      const cutoffDate = new Date();
-      cutoffDate.setDate(cutoffDate.getDate() - this.rollingWindowDays);
-      const cutoffStr = cutoffDate.toISOString().split('T')[0];
-      
+      // Stage every row whose startDate can become a timestamp. There is no
+      // history window; rows with an invalid or missing startDate are the only
+      // ones excluded.
       await this.db.run(`
         CREATE TABLE ${tempTableName} AS
         SELECT * FROM read_csv('${filePath}',
@@ -49,25 +43,21 @@ export class TableLoader {
           null_padding = true,
           new_line = '\\r\\n'
         )
-        WHERE TRY_CAST(SUBSTR(startDate, 1, 19) AS TIMESTAMP) >= '${cutoffStr}'
+        WHERE TRY_CAST(SUBSTR(startDate, 1, 19) AS TIMESTAMP) IS NOT NULL
       `);
-      
-      // Get row count
+
+      // A file with no readable rows still produces an empty final table so
+      // queries return zero rows instead of a missing-table error, and the CSV
+      // is not rescanned on every request.
+      await this.cleanAndOptimizeTable(tempTableName, tableName);
+
+      // Count the final table: cleanAndOptimizeTable also drops rows with a
+      // null value, so the catalog count matches what is actually stored.
       const countResult = await this.db.execute(
-        `SELECT COUNT(*) as count FROM ${tempTableName}`
+        `SELECT COUNT(*) as count FROM ${tableName}`
       );
-      const rowCount = countResult[0]?.count || 0;
-      
-      if (rowCount > 0) {
-        // Clean and create final table
-        await this.cleanAndOptimizeTable(tempTableName, tableName);
-        this.catalog.markLoaded(tableName, rowCount);
-        // console.log(`Loaded ${rowCount} rows into ${tableName}`);
-      } else {
-        // Drop empty staging table
-        await this.db.run(`DROP TABLE IF EXISTS ${tempTableName}`);
-        // console.log(`No recent data found for ${tableName}`);
-      }
+      const rowCount = Number(countResult[0]?.count ?? 0);
+      this.catalog.markLoaded(tableName, rowCount);
     } catch (error) {
       // Clean up on error
       await this.db.run(`DROP TABLE IF EXISTS ${tempTableName}`);

--- a/src/db/loader.ts
+++ b/src/db/loader.ts
@@ -47,7 +47,10 @@ export class TableLoader {
   }
 
   private csvSource(filePath: string): string {
-    return `read_csv('${filePath}',
+    // Paths are not user queries, but a directory name like "Neil's Health"
+    // contains a quote that would end the SQL literal early.
+    const escapedPath = filePath.replace(/'/g, "''");
+    return `read_csv('${escapedPath}',
         header = true,
         skip = 1,
         delim = ',',
@@ -81,6 +84,13 @@ export class TableLoader {
     const valueCol = columnByLower.get('value');
     const typeCol = columnByLower.get('type');
 
+    // Every consumer sorts and filters on startDate. A CSV without that column
+    // is not a loadable health export; fail here with a clear reason instead of
+    // materializing a table that breaks every downstream query.
+    if (!startDateCol) {
+      throw new Error(`CSV has no startDate column: ${filePath}`);
+    }
+
     const selectParts: string[] = [];
     for (const name of columnNames) {
       const lower = name.toLowerCase();
@@ -97,18 +107,15 @@ export class TableLoader {
     }
 
     // Keep every row whose startDate can become a timestamp. There is no
-    // history window; an invalid or missing startDate, and a null value where
-    // the shape has a value column, are the only exclusions.
-    const conditions: string[] = [];
-    if (startDateCol) {
-      conditions.push(`TRY_CAST(SUBSTR(${startDateCol}, 1, 19) AS TIMESTAMP) IS NOT NULL`);
-    }
+    // history window; an invalid startDate, and a null value where the shape
+    // has a value column, are the only exclusions.
+    const conditions: string[] = [
+      `TRY_CAST(SUBSTR(${startDateCol}, 1, 19) AS TIMESTAMP) IS NOT NULL`,
+    ];
     if (valueCol) {
       conditions.push(`${valueCol} IS NOT NULL`);
     }
-    const whereClause = conditions.length
-      ? `\n      WHERE ${conditions.join('\n        AND ')}`
-      : '';
+    const whereClause = `\n      WHERE ${conditions.join('\n        AND ')}`;
 
     // One pass from CSV straight into the typed final table. Staging the raw
     // rows first would hold both copies resident and roughly double peak memory
@@ -121,12 +128,10 @@ export class TableLoader {
     `);
 
     // Create indexes for common query patterns
-    if (startDateCol) {
-      await this.db.run(`
-        CREATE INDEX IF NOT EXISTS idx_${finalTable}_startdate
-        ON ${finalTable}(${startDateCol})
-      `);
-    }
+    await this.db.run(`
+      CREATE INDEX IF NOT EXISTS idx_${finalTable}_startdate
+      ON ${finalTable}(${startDateCol})
+    `);
 
     if (typeCol) {
       await this.db.run(`

--- a/src/server.ts
+++ b/src/server.ts
@@ -53,7 +53,7 @@ const schemaTool = new HealthSchemaTool(db, catalog, loader);
 // Create MCP server
 const server = new Server({
   name: "apple-health-mcp",
-  version: "1.2.1",
+  version: "1.3.0",
 }, {
   capabilities: {
     tools: {}

--- a/src/server.ts
+++ b/src/server.ts
@@ -23,7 +23,7 @@ import type { HealthQueryArgs, HealthReportArgs } from "./types.js";
 
 // Get configuration from environment
 const DATA_DIR = process.env.HEALTH_DATA_DIR || './HealthAll_2025-07-202_01-04-39_SimpleHealthExportCSV';
-const MAX_MEMORY_MB = parseInt(process.env.MAX_MEMORY_MB || '1024');
+const MAX_MEMORY_MB = parseInt(process.env.MAX_MEMORY_MB || '2048');
 const CACHE_SIZE = parseInt(process.env.CACHE_SIZE || '100');
 
 // Validate data directory

--- a/src/tools/health-query.test.ts
+++ b/src/tools/health-query.test.ts
@@ -1,0 +1,82 @@
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { HealthDataDB } from '../db/database';
+import { FileCatalog } from '../db/catalog';
+import { TableLoader } from '../db/loader';
+import { QueryCache } from '../core/cache';
+import { QueryOptimizer } from '../core/optimizer';
+import { HealthQueryTool } from './health-query';
+
+let dataDir: string;
+let db: HealthDataDB;
+let tool: HealthQueryTool;
+
+beforeAll(async () => {
+  dataDir = mkdtempSync(join(tmpdir(), 'health-query-test-'));
+  const rows = [
+    'sep=,',
+    'type,sourceName,sourceVersion,productType,device,startDate,endDate,unit,value',
+    'HKQuantityTypeIdentifierHeartRate,Apple Watch,10.0,Watch7,1,2019-04-08 07:15:00 +0000,2019-04-08 07:15:00 +0000,count/min,62'
+  ];
+  writeFileSync(
+    join(dataDir, 'HKQuantityTypeIdentifierHeartRate.csv'),
+    rows.join('\r\n') + '\r\n'
+  );
+
+  db = new HealthDataDB({ dataDir, maxMemoryMB: 512 });
+  await db.initialize();
+  const catalog = new FileCatalog(dataDir);
+  await catalog.initialize();
+  const loader = new TableLoader(db, catalog);
+  tool = new HealthQueryTool(db, new QueryCache(10), new QueryOptimizer(loader));
+});
+
+afterAll(async () => {
+  await db.close();
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe('HealthQueryTool accepted queries', () => {
+  test('runs a plain SELECT', async () => {
+    const result = await tool.execute({
+      query: 'SELECT COUNT(*) as count FROM hkquantitytypeidentifierheartrate'
+    });
+    expect(result.rowCount).toBe(1);
+    expect(Number(result.rows[0][0])).toBe(1);
+  });
+
+  test('allows OFFSET and words that merely contain a forbidden statement', async () => {
+    const result = await tool.execute({
+      query:
+        'SELECT value FROM hkquantitytypeidentifierheartrate ORDER BY startDate LIMIT 1 OFFSET 0'
+    });
+    expect(result.rowCount).toBe(1);
+  });
+});
+
+describe('HealthQueryTool rejected queries', () => {
+  const rejected: Array<[string, string]> = [
+    ["SET max_temp_directory_size = '10GB'", 'set'],
+    ['SELECT 1; PRAGMA database_list', 'pragma'],
+    ['RESET memory_limit', 'reset'],
+    ['DROP TABLE hkquantitytypeidentifierheartrate', 'drop'],
+    ['INSERT INTO hkquantitytypeidentifierheartrate VALUES (1)', 'insert'],
+    ['UPDATE hkquantitytypeidentifierheartrate SET value = 0', 'update']
+  ];
+
+  for (const [query, keyword] of rejected) {
+    test(`rejects ${keyword}`, async () => {
+      await expect(tool.execute({ query })).rejects.toThrow(
+        `forbidden keyword: ${keyword}`
+      );
+    });
+  }
+
+  test('rejects a statement with no SELECT', async () => {
+    await expect(tool.execute({ query: 'SHOW TABLES' })).rejects.toThrow(
+      'Only SELECT queries are allowed'
+    );
+  });
+});

--- a/src/tools/health-query.ts
+++ b/src/tools/health-query.ts
@@ -47,13 +47,20 @@ export class HealthQueryTool {
   private validateQuery(query: string): void {
     const forbidden = ['drop', 'delete', 'truncate', 'insert', 'update', 'create table', 'alter'];
     const queryLower = query.toLowerCase();
-    
+
     for (const keyword of forbidden) {
       if (queryLower.includes(keyword)) {
         throw new Error(`Query contains forbidden keyword: ${keyword}`);
       }
     }
-    
+
+    // Configuration statements could re-enable disk spill or change limits the
+    // server set at startup. Word boundaries keep OFFSET and column names legal.
+    const configStatement = /\b(set|reset|pragma)\b/i.exec(query);
+    if (configStatement) {
+      throw new Error(`Query contains forbidden keyword: ${configStatement[1].toLowerCase()}`);
+    }
+
     if (!queryLower.includes('select')) {
       throw new Error('Only SELECT queries are allowed');
     }

--- a/src/tools/health-report.test.ts
+++ b/src/tools/health-report.test.ts
@@ -207,6 +207,69 @@ describe('HealthReportTool workouts', () => {
   });
 });
 
+describe('HealthReportTool over a historical period', () => {
+  test('reports data from an export that contains only old rows', async () => {
+    const oldDir = mkdtempSync(join(tmpdir(), 'health-report-old-'));
+
+    // Fixed 2019 dates: the wall clock must not change this result.
+    const rows: string[] = [];
+    for (let day = 1; day <= 7; day++) {
+      const stamp = `2019-04-0${day} 09:00:00 +0000`;
+      rows.push(
+        `HKQuantityTypeIdentifierHeartRate,Apple Watch,10.0,Watch7,1,${stamp},${stamp},count/min,${64 + day}`
+      );
+    }
+    writeCsv(oldDir, 'HKQuantityTypeIdentifierHeartRate.csv', QUANTITY_HEADER, rows);
+
+    const oldDb = new HealthDataDB({ dataDir: oldDir, maxMemoryMB: 512 });
+    await oldDb.initialize();
+    const catalog = new FileCatalog(oldDir);
+    await catalog.initialize();
+    const loader = new TableLoader(oldDb, catalog);
+    const reportTool = new HealthReportTool(oldDb, new QueryCache(100), catalog, loader);
+
+    const result = await reportTool.execute({
+      report_type: 'custom',
+      start_date: '2019-04-01',
+      end_date: '2019-04-30',
+      include_metrics: ['heart_rate']
+    });
+
+    const data = sectionByTitle(result, 'Heart Rate').data;
+    expect(Number(data.totalReadings)).toBe(7);
+    expect(Number(data.daysWithData)).toBe(7);
+
+    await oldDb.close();
+    rmSync(oldDir, { recursive: true, force: true });
+  });
+});
+
+describe('HealthReportTool when a table cannot load', () => {
+  test('fails the report instead of calling the metric absent', async () => {
+    const brokenDir = mkdtempSync(join(tmpdir(), 'health-report-broken-'));
+    writeFixtures(brokenDir, { heartRateOnly: true });
+
+    const brokenDb = new HealthDataDB({ dataDir: brokenDir, maxMemoryMB: 512 });
+    await brokenDb.initialize();
+    const catalog = new FileCatalog(brokenDir);
+    await catalog.initialize();
+
+    // Point the catalog entry at a file that does not exist so the load throws.
+    const entry = catalog.getEntry('hkquantitytypeidentifierheartrate')!;
+    entry.path = join(brokenDir, 'does-not-exist.csv');
+
+    const loader = new TableLoader(brokenDb, catalog);
+    const reportTool = new HealthReportTool(brokenDb, new QueryCache(100), catalog, loader);
+
+    await expect(
+      reportTool.execute({ report_type: 'weekly', include_metrics: ['heart_rate'] })
+    ).rejects.toThrow(/hkquantitytypeidentifierheartrate/);
+
+    await brokenDb.close();
+    rmSync(brokenDir, { recursive: true, force: true });
+  });
+});
+
 describe('HealthReportTool with a missing metric', () => {
   test('says so instead of dropping the section', async () => {
     const emptyDir = mkdtempSync(join(tmpdir(), 'health-report-empty-'));

--- a/src/tools/health-report.ts
+++ b/src/tools/health-report.ts
@@ -35,13 +35,11 @@ export class HealthReportTool {
     // Generate report sections
     const sections: ReportSection[] = [];
 
+    // A load or query failure stops the report so the MCP server returns a tool
+    // error. Absent metrics are reported as missing sections, not as failures.
     for (const metric of metrics) {
-      try {
-        const section = await this.generateSection(metric, dateRange);
-        if (section) sections.push(section);
-      } catch (error) {
-        console.error(`Failed to generate ${metric} section:`, error);
-      }
+      const section = await this.generateSection(metric, dateRange);
+      if (section) sections.push(section);
     }
 
     // Create final report
@@ -105,23 +103,16 @@ export class HealthReportTool {
   }
 
   // Tables load on demand, so a report on a cold server has to load what it
-  // needs before querying. Returns the tables that actually exist afterwards -
-  // the loader skips tables with no rows in the rolling window.
+  // needs before querying. A table the export does not contain is an absent
+  // metric, but a load failure is a real error and stops the report.
   private async ensureTables(tableNames: string[]): Promise<string[]> {
     const loaded: string[] = [];
 
     for (const tableName of tableNames) {
       if (!this.catalog.getEntry(tableName)) continue;
 
-      try {
-        await this.loader.ensureTableLoaded(tableName);
-      } catch {
-        continue;
-      }
-
-      if (this.catalog.getEntry(tableName)?.loaded) {
-        loaded.push(tableName);
-      }
+      await this.loader.ensureTableLoaded(tableName);
+      loaded.push(tableName);
     }
 
     return loaded;

--- a/src/tools/health-schema.test.ts
+++ b/src/tools/health-schema.test.ts
@@ -197,6 +197,44 @@ describe('HealthSchemaTool with an old-only export', () => {
   });
 });
 
+describe('HealthSchemaTool with an unreadable export', () => {
+  let emptyDir: string;
+  let emptyDb: HealthDataDB;
+  let emptySchema: any;
+
+  beforeAll(async () => {
+    emptyDir = mkdtempSync(join(tmpdir(), 'health-schema-empty-'));
+
+    // Every row has an unparseable startDate, so nothing survives staging.
+    writeCsv(
+      emptyDir,
+      'HKQuantityTypeIdentifierStepCount.csv',
+      'type,sourceName,sourceVersion,productType,device,startDate,endDate,unit,value',
+      ['HKQuantityTypeIdentifierStepCount,iPhone,18.0,iPhone15,1,not-a-date,not-a-date,count,7000']
+    );
+
+    emptyDb = new HealthDataDB({ dataDir: emptyDir, maxMemoryMB: 512 });
+    await emptyDb.initialize();
+    const emptyCatalog = new FileCatalog(emptyDir);
+    await emptyCatalog.initialize();
+    const emptyLoader = new TableLoader(emptyDb, emptyCatalog);
+
+    emptySchema = await new HealthSchemaTool(emptyDb, emptyCatalog, emptyLoader).execute();
+  });
+
+  afterAll(async () => {
+    await emptyDb.close();
+    rmSync(emptyDir, { recursive: true, force: true });
+  });
+
+  test('gives a neutral note that does not blame a date window', () => {
+    const details = emptySchema.tableDetails['hkquantitytypeidentifierstepcount'];
+    expect(details.note).toBe('no readable rows in this file');
+    expect(details.note).not.toContain('90');
+    expect(details.note).not.toContain('window');
+  });
+});
+
 describe('HealthSchemaTool rescan', () => {
   test('finds a workout export written after the first execute', async () => {
     expect(schema.availableTables).not.toContain('hkworkoutactivitytyperunning');

--- a/src/tools/health-schema.test.ts
+++ b/src/tools/health-schema.test.ts
@@ -229,7 +229,7 @@ describe('HealthSchemaTool with an unreadable export', () => {
 
   test('gives a neutral note that does not blame a date window', () => {
     const details = emptySchema.tableDetails['hkquantitytypeidentifierstepcount'];
-    expect(details.note).toBe('no readable rows in this file');
+    expect(details.note).toBe('no rows loaded from this file (unparseable dates or empty values)');
     expect(details.note).not.toContain('90');
     expect(details.note).not.toContain('window');
   });

--- a/src/tools/health-schema.test.ts
+++ b/src/tools/health-schema.test.ts
@@ -8,6 +8,8 @@ import { TableLoader } from '../db/loader';
 import { HealthSchemaTool } from './health-schema';
 
 const RECENT_HEART_RATE_ROWS = 120;
+const OLD_HEART_RATE_ROWS = 5;
+const TOTAL_HEART_RATE_ROWS = RECENT_HEART_RATE_ROWS + OLD_HEART_RATE_ROWS;
 
 function formatTimestamp(date: Date): string {
   return `${date.toISOString().slice(0, 19).replace('T', ' ')} +0000`;
@@ -18,6 +20,9 @@ function daysAgo(days: number): Date {
   date.setDate(date.getDate() - days);
   return date;
 }
+
+// A fixed historical date proves the loader cannot depend on the wall clock.
+const OLD_EXPORT_DATE = new Date('2019-04-08T07:15:00Z');
 
 function writeCsv(dir: string, fileName: string, header: string, rows: string[]): void {
   const lines = ['sep=,', header, ...rows];
@@ -40,8 +45,10 @@ beforeAll(async () => {
       `HKQuantityTypeIdentifierHeartRate,Apple Watch,10.0,Watch7,1,${start},${start},count/min,${60 + (i % 40)}`
     );
   }
-  for (let i = 0; i < 5; i++) {
-    const start = formatTimestamp(daysAgo(200 + i));
+  for (let i = 0; i < OLD_HEART_RATE_ROWS; i++) {
+    const old = new Date(OLD_EXPORT_DATE);
+    old.setUTCDate(old.getUTCDate() + i);
+    const start = formatTimestamp(old);
     heartRateRows.push(
       `HKQuantityTypeIdentifierHeartRate,Apple Watch,10.0,Watch7,1,${start},${start},count/min,${50 + i}`
     );
@@ -89,17 +96,25 @@ afterAll(async () => {
 });
 
 describe('HealthSchemaTool', () => {
-  test('loads the full rolling window, not a 100 row sample', async () => {
+  test('loads every row, not a 100 row sample', async () => {
     const result = await db.execute(
       'SELECT COUNT(*) as count FROM hkquantitytypeidentifierheartrate'
     );
-    expect(Number(result[0].count)).toBe(RECENT_HEART_RATE_ROWS);
+    expect(Number(result[0].count)).toBe(TOTAL_HEART_RATE_ROWS);
+  });
+
+  test('reports the full row count and an earliest date years in the past', () => {
+    const stats = schema.tableDetails['hkquantitytypeidentifierheartrate'].statistics;
+    expect(Number(stats.total_rows)).toBe(TOTAL_HEART_RATE_ROWS);
+
+    const earliest = new Date(String(stats.earliest_date)).getTime();
+    expect(earliest).toBe(Date.UTC(2019, 3, 8));
   });
 
   test('records the real row count in the catalog', () => {
     const entry = catalog.getEntry('hkquantitytypeidentifierheartrate');
     expect(entry?.loaded).toBe(true);
-    expect(Number(entry?.rowCount)).toBe(RECENT_HEART_RATE_ROWS);
+    expect(Number(entry?.rowCount)).toBe(TOTAL_HEART_RATE_ROWS);
   });
 
   test('reports the primary unit for a quantity table', () => {
@@ -132,6 +147,53 @@ describe('HealthSchemaTool', () => {
     expect(schema.summary.loadedTables).toBeUndefined();
     expect(schema.summary.tablesInMemory).toBeGreaterThan(0);
     expect(schema.summary.loadingNote).toContain('on demand');
+  });
+});
+
+describe('HealthSchemaTool with an old-only export', () => {
+  let oldDir: string;
+  let oldDb: HealthDataDB;
+  let oldSchema: any;
+
+  beforeAll(async () => {
+    oldDir = mkdtempSync(join(tmpdir(), 'health-schema-old-'));
+
+    const rows: string[] = [];
+    for (let i = 0; i < 20; i++) {
+      const stamp = new Date(OLD_EXPORT_DATE);
+      stamp.setUTCDate(stamp.getUTCDate() + i);
+      const start = formatTimestamp(stamp);
+      rows.push(
+        `HKQuantityTypeIdentifierStepCount,iPhone,18.0,iPhone15,1,${start},${start},count,${7000 + i}`
+      );
+    }
+    writeCsv(
+      oldDir,
+      'HKQuantityTypeIdentifierStepCount.csv',
+      'type,sourceName,sourceVersion,productType,device,startDate,endDate,unit,value',
+      rows
+    );
+
+    oldDb = new HealthDataDB({ dataDir: oldDir, maxMemoryMB: 512 });
+    await oldDb.initialize();
+    const oldCatalog = new FileCatalog(oldDir);
+    await oldCatalog.initialize();
+    const oldLoader = new TableLoader(oldDb, oldCatalog);
+
+    oldSchema = await new HealthSchemaTool(oldDb, oldCatalog, oldLoader).execute();
+  });
+
+  afterAll(async () => {
+    await oldDb.close();
+    rmSync(oldDir, { recursive: true, force: true });
+  });
+
+  test('makes a table whose rows are all years old available', () => {
+    const details = oldSchema.tableDetails['hkquantitytypeidentifierstepcount'];
+    expect(details.available).toBeUndefined();
+    expect(details.note).toBeUndefined();
+    expect(details.error).toBeUndefined();
+    expect(Number(details.statistics.total_rows)).toBe(20);
   });
 });
 

--- a/src/tools/health-schema.ts
+++ b/src/tools/health-schema.ts
@@ -62,11 +62,12 @@ export class HealthSchemaTool {
         // A load failure throws and is reported by the catch below.
         await this.loader.ensureTableLoaded(tableName);
 
-        // A file whose rows are all unreadable still loads as an empty table.
-        // Say so plainly rather than reporting empty statistics.
+        // A file can load as an empty table when its dates are unparseable or
+        // every value is null. Say so plainly rather than reporting empty
+        // statistics.
         if (this.catalog.getEntry(tableName)?.rowCount === 0) {
           schema.tableDetails[tableName] = {
-            note: 'no readable rows in this file'
+            note: 'no rows loaded from this file (unparseable dates or empty values)'
           };
           continue;
         }

--- a/src/tools/health-schema.ts
+++ b/src/tools/health-schema.ts
@@ -58,16 +58,15 @@ export class HealthSchemaTool {
     // Get schema information for sample tables
     for (const tableName of sampleTables) {
       try {
-        // Load the full rolling window through the loader so later queries see all rows
+        // Materialize the table's full history so later queries see every row.
+        // A load failure throws and is reported by the catch below.
         await this.loader.ensureTableLoaded(tableName);
 
-        // The loader skips tables with no rows in the rolling window, so the table
-        // may not exist. Report that instead of querying a missing table.
-        const entry = this.catalog.getEntry(tableName);
-        if (!entry?.loaded) {
+        // A file whose rows are all unreadable still loads as an empty table.
+        // Say so plainly rather than reporting empty statistics.
+        if (this.catalog.getEntry(tableName)?.rowCount === 0) {
           schema.tableDetails[tableName] = {
-            note: 'no data in the rolling window (last 90 days)',
-            available: false
+            note: 'no readable rows in this file'
           };
           continue;
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,7 +23,6 @@ export interface HealthDataConfig {
   cacheDir?: string;
   maxMemoryMB?: number;
   prewarmCache?: boolean;
-  rollingWindowDays?: number;
 }
 
 export type OutputFormat = 'json' | 'csv' | 'summary';


### PR DESCRIPTION
## Summary

This change removes the hidden 90-day load window. The server now loads the full history of each CSV file. A two-year export is fully queryable.

Before this change, the loader dropped all rows older than 90 days. The cutoff came from the computer clock. A valid old export looked empty. No benchmark or requirement supported the limit.

## Changes

- The loader keeps every row that has a valid `startDate`. No date window remains.
- The loader reads each CSV in a single pass. The old staging copy doubled peak memory and caused out-of-memory failures on large exports.
- The default memory limit is now 2048 MB. Set `MAX_MEMORY_MB` to change it.
- DuckDB gets a temp-directory budget of 0 bytes. Health rows cannot spill to disk. A load that does not fit fails with a clear error.
- Load failures now reach the client as tool errors. A metric that is not in the export still shows a "no data" section.
- The loader rejects a CSV without a `startDate` column, quotes all header-derived identifiers, and escapes quotes in file paths.
- `health_query` rejects `SET`, `RESET`, and `PRAGMA`.
- Docs describe the new behavior. Version is 1.3.0 in all three locations.

## Measurements, generated data

Default settings, real load path, Apple M3 Max, DuckDB 1.4.4:

| Set | Rows | Load time | Peak RSS | Result |
| --- | --- | --- | --- | --- |
| Small | 10,000 | 0.05 s | 91 MB | Pass |
| Medium | 100,000 | 0.20 s | 127 MB | Pass |
| Large | 6,000,000 | 2.02 s | 1,419 MB | Pass |

The large set fails at the old 1024 MB default. The failure is a loud out-of-memory error. No data reaches disk. The single-pass loader and the 2048 MB default are both necessary.

## Verification, real exports

| Export | Tables | Rows | Load time | Peak RSS |
| --- | --- | --- | --- | --- |
| ~90 days, 88 MB | 100/100 | 295,690 | 0.91 s | 417 MB |
| ~2 years, 467 MB | 100/100 | 1,152,179 | 2.24 s | 935 MB |

The two-year export exposes its full 2024-05 to 2026-08 range to all three tools. No spill files appear. Real data also exposed one latent bug: Withings CSV headers contain column names with spaces, which broke the load SQL. This is fixed and covered by a test.

## Tests

61 tests pass, up from 38. Every commit on this branch passes the full suite. Typecheck and build are clean.