### PR TITLE
Add MCP prompts, resources, and resilient startup

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Neil Pullman
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neiltron/apple-health-mcp",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "mcpName": "io.github.neiltron/apple-health-mcp",
   "description": "MCP server for querying Apple Health data with DuckDB",
   "main": "dist/server.js",

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/neiltron/apple-health-mcp",
     "source": "github"
   },
-  "version": "1.3.0",
+  "version": "1.4.0",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@neiltron/apple-health-mcp",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/src/prompts.test.ts
+++ b/src/prompts.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+import { PROMPTS, buildPromptMessages } from "./prompts";
+
+describe("PROMPTS", () => {
+  test("every prompt has a name, description, and argument descriptions", () => {
+    expect(PROMPTS.length).toBeGreaterThan(0);
+    for (const prompt of PROMPTS) {
+      expect(prompt.name).toBeTruthy();
+      expect(prompt.description).toBeTruthy();
+      for (const argument of prompt.arguments) {
+        expect(argument.name).toBeTruthy();
+        expect(argument.description).toBeTruthy();
+      }
+    }
+  });
+});
+
+describe("buildPromptMessages", () => {
+  test("every listed prompt resolves with no arguments", () => {
+    for (const prompt of PROMPTS) {
+      const result = buildPromptMessages(prompt.name, {});
+      expect(result.description).toBe(prompt.description);
+      expect(result.messages.length).toBeGreaterThan(0);
+      expect(result.messages[0].content.text.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("weekly_summary includes the start date when provided", () => {
+    const result = buildPromptMessages("weekly_summary", {
+      start_date: "2026-08-03"
+    });
+    expect(result.messages[0].content.text).toContain("2026-08-03");
+    expect(result.messages[0].content.text).toContain('"custom"');
+  });
+
+  test("weekly_summary defaults to the weekly report without a start date", () => {
+    const result = buildPromptMessages("weekly_summary", {});
+    expect(result.messages[0].content.text).toContain('"weekly"');
+  });
+
+  test("sleep_analysis uses the provided day count", () => {
+    const result = buildPromptMessages("sleep_analysis", { days: "30" });
+    expect(result.messages[0].content.text).toContain("last 30 days");
+  });
+
+  test("sleep_analysis falls back to the default on invalid day counts", () => {
+    for (const days of [undefined, "not-a-number", "-5", "0"]) {
+      const result = buildPromptMessages("sleep_analysis", { days });
+      expect(result.messages[0].content.text).toContain("last 14 days");
+    }
+  });
+
+  test("workout_progress defaults to 90 days", () => {
+    const result = buildPromptMessages("workout_progress", {});
+    expect(result.messages[0].content.text).toContain("last 90 days");
+  });
+
+  test("unknown prompt names throw", () => {
+    expect(() => buildPromptMessages("nope", {})).toThrow("Unknown prompt: nope");
+  });
+});

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -1,0 +1,123 @@
+// Prompt templates exposed over MCP prompts/list and prompts/get. Each prompt
+// compiles the data-model rules from docs/querying.md into instructions a
+// client model can follow with the health_schema/health_query/health_report
+// tools.
+
+export interface PromptDefinition {
+  name: string;
+  description: string;
+  arguments: Array<{
+    name: string;
+    description: string;
+    required: boolean;
+  }>;
+}
+
+export const PROMPTS: PromptDefinition[] = [
+  {
+    name: "weekly_summary",
+    description:
+      "Summarize the most recent week of health data: activity, heart rate, sleep, and workouts",
+    arguments: [
+      {
+        name: "start_date",
+        description:
+          "Week start date (YYYY-MM-DD). Defaults to the most recent full week.",
+        required: false
+      }
+    ]
+  },
+  {
+    name: "sleep_analysis",
+    description:
+      "Analyze sleep duration, stages, and consistency over a recent period",
+    arguments: [
+      {
+        name: "days",
+        description: "Number of days to analyze (default 14)",
+        required: false
+      }
+    ]
+  },
+  {
+    name: "workout_progress",
+    description:
+      "Review workout frequency, duration, and trends over a recent period",
+    arguments: [
+      {
+        name: "days",
+        description: "Number of days to analyze (default 90)",
+        required: false
+      }
+    ]
+  }
+];
+
+const SHARED_RULES = `Ground rules for querying this data:
+- Call health_schema first to see which tables this export actually contains.
+- Only SELECT queries are accepted by health_query.
+- Check the unit column before combining values; units vary by source device.
+- Multiple devices can record overlapping rows, so per-source breakdowns are safer than naive sums.
+- Category tables (e.g. sleep stages) keep their label in valueText; their numeric value is NULL.
+- Derive durations from startDate and endDate, e.g. DATE_DIFF('second', startDate, endDate).`;
+
+function positiveInt(raw: string | undefined, fallback: number): number {
+  const parsed = Number.parseInt(raw ?? "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+export function buildPromptMessages(
+  name: string,
+  args: Record<string, string | undefined>
+): { description: string; messages: Array<{ role: "user"; content: { type: "text"; text: string } }> } {
+  const definition = PROMPTS.find((prompt) => prompt.name === name);
+  if (!definition) {
+    throw new Error(`Unknown prompt: ${name}`);
+  }
+
+  let text: string;
+  switch (name) {
+    case "weekly_summary": {
+      const start = args.start_date;
+      text = `Produce a weekly health summary${start ? ` for the week starting ${start}` : " for the most recent full week"}.
+
+Start with the health_report tool (report_type: ${start ? `"custom" with start_date/end_date` : `"weekly"`}), then use health_query to drill into anything notable.
+
+${SHARED_RULES}
+
+Structure the summary as: overall activity (steps, distance, energy), heart rate ranges, sleep totals, and workouts. Close with 2-3 concrete observations or trends worth watching.`;
+      break;
+    }
+    case "sleep_analysis": {
+      const days = positiveInt(args.days, 14);
+      text = `Analyze my sleep over the last ${days} days using the sleep analysis table.
+
+${SHARED_RULES}
+
+Sleep specifics:
+- Stage labels live in valueText; sum DATE_DIFF('second', startDate, endDate) per stage per night.
+- Total asleep time should match LOWER(valueText) LIKE '%asleep%' to exclude awake and in-bed rows.
+
+Report nightly totals, average sleep duration, stage breakdown, bedtime/wake-time consistency, and any nights that stand out.`;
+      break;
+    }
+    case "workout_progress": {
+      const days = positiveInt(args.days, 90);
+      text = `Review my workout progress over the last ${days} days.
+
+Use health_schema's commonPatterns.workouts to find the workout tables in this export (they may be one combined table or one per activity type).
+
+${SHARED_RULES}
+
+Report workouts per week, duration trends (from startDate/endDate, not exported duration fields), the mix of activity types, and whether volume is trending up or down.`;
+      break;
+    }
+    default:
+      throw new Error(`Unknown prompt: ${name}`);
+  }
+
+  return {
+    description: definition.description,
+    messages: [{ role: "user", content: { type: "text", text } }]
+  };
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -276,8 +276,24 @@ async function main() {
     // console.log('Initializing database...');
     await db.initialize();
     
-    // console.log('Scanning health data files...');
-    await catalog.initialize();
+    // Scan health data files. A missing or unreadable data directory must not
+    // prevent startup: clients can still connect and list tools, and
+    // health_schema reports the empty catalog with a pointer to
+    // HEALTH_DATA_DIR. health_schema's refresh() picks the files up once the
+    // directory appears. Warnings go to stderr; stdout is reserved for the
+    // protocol.
+    try {
+      await catalog.initialize();
+      if (Object.keys(catalog.getTableInfo()).length === 0) {
+        process.stderr.write(
+          `apple-health-mcp: no health CSV files found in HEALTH_DATA_DIR (${DATA_DIR}); starting with no tables\n`
+        );
+      }
+    } catch (error) {
+      process.stderr.write(
+        `apple-health-mcp: could not read HEALTH_DATA_DIR (${DATA_DIR}): ${error instanceof Error ? error.message : String(error)}; starting with no tables\n`
+      );
+    }
     
     // Start memory monitoring
     memoryManager.startMonitoring();

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,6 +7,8 @@ import {
   ListToolsRequestSchema,
   ListPromptsRequestSchema,
   GetPromptRequestSchema,
+  ListResourcesRequestSchema,
+  ReadResourceRequestSchema,
   ErrorCode,
   McpError
 } from "@modelcontextprotocol/sdk/types.js";
@@ -60,7 +62,8 @@ const server = new Server({
 }, {
   capabilities: {
     tools: {},
-    prompts: {}
+    prompts: {},
+    resources: {}
   }
 });
 
@@ -145,6 +148,74 @@ server.setRequestHandler(GetPromptRequestSchema, async (request) => {
       ErrorCode.InvalidParams,
       error instanceof Error ? error.message : String(error)
     );
+  }
+});
+
+// List readable resources
+server.setRequestHandler(ListResourcesRequestSchema, async () => ({
+  resources: [
+    {
+      uri: "health://schema",
+      name: "Health data schema",
+      description:
+        "Tables, columns, units, sample rows, and query tips for the loaded export",
+      mimeType: "application/json"
+    },
+    {
+      uri: "health://tables",
+      name: "Available tables",
+      description:
+        "Every queryable table in the export with its load state and row count",
+      mimeType: "application/json"
+    }
+  ]
+}));
+
+// Read a resource
+server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
+  const { uri } = request.params;
+
+  switch (uri) {
+    case "health://schema":
+      return {
+        contents: [{
+          uri,
+          mimeType: "application/json",
+          text: JSON.stringify(await schemaTool.execute(), jsonReplacer, 2)
+        }]
+      };
+
+    case "health://tables": {
+      // Pick up files exported after startup; keep the current catalog if the
+      // rescan fails.
+      try {
+        await catalog.refresh();
+      } catch {
+        // keep the existing catalog
+      }
+      // Report table names only; catalog entries also hold local file paths,
+      // which stay out of protocol responses.
+      const tables = Object.entries(catalog.getTableInfo())
+        .map(([name, entry]) => ({
+          name,
+          loaded: entry.loaded,
+          rowCount: entry.rowCount
+        }))
+        .sort((a, b) => a.name.localeCompare(b.name));
+      return {
+        contents: [{
+          uri,
+          mimeType: "application/json",
+          text: JSON.stringify({ totalTables: tables.length, tables }, jsonReplacer, 2)
+        }]
+      };
+    }
+
+    default:
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        `Unknown resource: ${uri}`
+      );
   }
 });
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,6 +5,8 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
+  ListPromptsRequestSchema,
+  GetPromptRequestSchema,
   ErrorCode,
   McpError
 } from "@modelcontextprotocol/sdk/types.js";
@@ -19,6 +21,7 @@ import { HealthQueryTool } from "./tools/health-query.js";
 import { HealthReportTool } from "./tools/health-report.js";
 import { HealthSchemaTool } from "./tools/health-schema.js";
 import { jsonReplacer } from "./utils.js";
+import { PROMPTS, buildPromptMessages } from "./prompts.js";
 import type { HealthQueryArgs, HealthReportArgs } from "./types.js";
 
 // Get configuration from environment
@@ -56,7 +59,8 @@ const server = new Server({
   version: "1.3.0",
 }, {
   capabilities: {
-    tools: {}
+    tools: {},
+    prompts: {}
   }
 });
 
@@ -123,6 +127,26 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
     }
   ]
 }));
+
+// List prompt templates
+server.setRequestHandler(ListPromptsRequestSchema, async () => ({
+  prompts: PROMPTS
+}));
+
+// Resolve a prompt template into messages
+server.setRequestHandler(GetPromptRequestSchema, async (request) => {
+  try {
+    return buildPromptMessages(
+      request.params.name,
+      (request.params.arguments ?? {}) as Record<string, string | undefined>
+    );
+  } catch (error) {
+    throw new McpError(
+      ErrorCode.InvalidParams,
+      error instanceof Error ? error.message : String(error)
+    );
+  }
+});
 
 // Handle tool calls
 server.setRequestHandler(CallToolRequestSchema, async (request) => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -58,7 +58,7 @@ const schemaTool = new HealthSchemaTool(db, catalog, loader);
 // Create MCP server
 const server = new Server({
   name: "apple-health-mcp",
-  version: "1.3.0",
+  version: "1.4.0",
 }, {
   capabilities: {
     tools: {},


### PR DESCRIPTION
## Changes

- Add three prompt templates: `weekly_summary`, `sleep_analysis`, and `workout_progress`. Each prompt encodes the data-model rules from `docs/querying.md`.
- Add two resources: `health://schema` and `health://tables`. Resource output does not include local file paths.
- Start the server when the data directory is missing or empty. Write a warning to stderr. Do not exit.
- Add the MIT license file.
- Bump the version to 1.4.0.

## Tests

- 69 tests pass. Typecheck and build pass.
- Verified `initialize`, `tools/list`, `prompts/list`, `resources/list`, and a `health_schema` call over stdio, with and without a data directory. Stdout stays protocol-only.