### PR TITLE
Fix silent row loss from sampled CSV type sniffing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neiltron/apple-health-mcp",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "mcpName": "io.github.neiltron/apple-health-mcp",
   "description": "MCP server for querying Apple Health data with DuckDB",
   "main": "dist/server.js",

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/neiltron/apple-health-mcp",
     "source": "github"
   },
-  "version": "1.4.0",
+  "version": "1.4.1",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@neiltron/apple-health-mcp",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/src/db/loader.test.ts
+++ b/src/db/loader.test.ts
@@ -10,6 +10,11 @@ const RECENT_ROWS = 120;
 const OLD_ROWS = 5;
 const TOTAL_HEART_RATE_ROWS = RECENT_ROWS + OLD_ROWS;
 
+// More numeric-looking rows than the sniffer's default ~20,480-row sample, so
+// the type-drift fixture only loads fully when the whole file is sniffed.
+const DRIFT_NUMERIC_ROWS = 21_000;
+const DRIFT_TEXT_ROWS = 500;
+
 // Fixed historical anchors keep every assertion independent of the current
 // date. The old anchor sits decades back so even a generous re-added
 // wall-clock window would fail these tests, not just a 90-day one.
@@ -175,6 +180,30 @@ beforeAll(async () => {
     'HKQuantityTypeIdentifierNoDates.csv',
     'type,sourceName,unit,value',
     ['HKQuantityTypeIdentifierNoDates,Manual,count,1']
+  );
+
+  // Type-drift shape: sourceVersion looks numeric ("10.5") for more rows than
+  // the CSV sniffer samples by default (~20k), then turns non-numeric
+  // ("11.0.1"). A sampled type guess makes every later row a CAST error that
+  // ignore_errors silently drops.
+  const driftRows: string[] = [];
+  for (let i = 0; i < DRIFT_NUMERIC_ROWS; i++) {
+    const start = formatTimestamp(daysAfter(RECENT_ANCHOR, i % 90));
+    driftRows.push(
+      `HKQuantityTypeIdentifierVO2Max,Apple Watch,10.5,Watch7,1,${start},${start},mL/min·kg,${35 + (i % 10)}`
+    );
+  }
+  for (let i = 0; i < DRIFT_TEXT_ROWS; i++) {
+    const start = formatTimestamp(daysAfter(RECENT_ANCHOR, 90 + (i % 30)));
+    driftRows.push(
+      `HKQuantityTypeIdentifierVO2Max,Apple Watch,11.0.1,Watch7,1,${start},${start},mL/min·kg,${40 + (i % 10)}`
+    );
+  }
+  writeCsv(
+    dataDir,
+    'HKQuantityTypeIdentifierVO2Max.csv',
+    QUANTITY_HEADER,
+    driftRows
   );
 
   db = new HealthDataDB({ dataDir, maxMemoryMB: 512 });
@@ -381,6 +410,25 @@ describe('TableLoader shape validation', () => {
       WHERE table_name = 'hkquantitytypeidentifiernodates'
     `);
     expect(tables.length).toBe(0);
+  });
+});
+
+describe('TableLoader type sniffing', () => {
+  test('keeps every row when a metadata column changes type past the sample window', async () => {
+    await loader.ensureTableLoaded('hkquantitytypeidentifiervo2max');
+
+    const rows = await db.execute(
+      'SELECT COUNT(*) as count FROM hkquantitytypeidentifiervo2max'
+    );
+    expect(Number(rows[0].count)).toBe(DRIFT_NUMERIC_ROWS + DRIFT_TEXT_ROWS);
+
+    // The rows after the drift are the ones a sampled type guess would drop.
+    const lateRows = await db.execute(`
+      SELECT COUNT(*) as count
+      FROM hkquantitytypeidentifiervo2max
+      WHERE sourceVersion = '11.0.1'
+    `);
+    expect(Number(lateRows[0].count)).toBe(DRIFT_TEXT_ROWS);
   });
 });
 

--- a/src/db/loader.ts
+++ b/src/db/loader.ts
@@ -57,6 +57,10 @@ export class TableLoader {
     // Paths are not user queries, but a directory name like "Neil's Health"
     // contains a quote that would end the SQL literal early.
     const escapedPath = filePath.replace(/'/g, "''");
+    // sample_size = -1 sniffs column types from the whole file, not the first
+    // ~20k rows. Metadata columns like sourceVersion look numeric for months
+    // ("10.5") and then stop ("11.0.1"); a sampled DOUBLE guess turns every
+    // later row into a CAST error that ignore_errors silently drops.
     return `read_csv('${escapedPath}',
         header = true,
         skip = 1,
@@ -65,7 +69,8 @@ export class TableLoader {
         escape = '"',
         ignore_errors = true,
         null_padding = true,
-        new_line = '\\r\\n'
+        new_line = '\\r\\n',
+        sample_size = -1
       )`;
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -58,7 +58,7 @@ const schemaTool = new HealthSchemaTool(db, catalog, loader);
 // Create MCP server
 const server = new Server({
   name: "apple-health-mcp",
-  version: "1.4.0",
+  version: "1.4.1",
 }, {
   capabilities: {
     tools: {},


### PR DESCRIPTION
Fixes #23

## Changes

- Set `sample_size = -1` in `read_csv`. DuckDB now infers column types from the whole file, not the first ~20k rows.
- Add a regression test. The fixture has 21,500 rows. The `sourceVersion` column changes from `10.5` to `11.0.1` after the default sample window.
- Bump the version to 1.4.1.

## Impact

On a real export, the heart rate table went from 127,612 loaded rows to the full 396,444. Two other tables recovered dropped rows in the same way.

## Tests

- 70 tests pass. Typecheck and build pass.
- The new test fails on the old loader and passes on the fixed loader.
- Full-file sniffing adds ~0.4 s for a 116 MB file.