### PR TITLE
refactor: extract format importers behind a FormatImporter interface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,9 @@ Tests use Bun. The published runtime requires Node.js 22 or newer.
 ## Code map
 
 - `src/server.ts`: configuration, MCP tool schemas, dispatch, and stdio startup
-- `src/db/`: CSV catalog, lazy table loader, and DuckDB wrapper
+- `src/importers/`: per-format ingestion (detection and loading) behind the
+  `FormatImporter` interface, plus the single-format registry
+- `src/db/`: format-agnostic catalog, lazy table loader, and DuckDB wrapper
 - `src/tools/`: implementations of `health_schema`, `health_query`, and
   `health_report`
 - `src/core/`: query caching, lazy-load coordination, and memory management

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,22 +9,45 @@ each request into an in-memory DuckDB database.
 1. `src/server.ts` reads `HEALTH_DATA_DIR`, `MAX_MEMORY_MB`, and `CACHE_SIZE`.
 2. `HealthDataDB` creates an in-memory DuckDB database and applies its memory
    limit.
-3. `FileCatalog` scans the export directory and maps recognized filenames to
-   lowercase table names. It does not load CSV contents during startup.
+3. `FileCatalog` scans the export directory through the importer registry:
+   each format importer's `detect` claims its files and maps them to canonical
+   lowercase table names with a table kind. No data is loaded during startup.
 4. An MCP request is dispatched to `health_schema`, `health_query`, or
    `health_report`.
-5. `TableLoader` loads the required CSVs into DuckDB, normalizes important
-   columns, and adds indexes for dates and metric types.
+5. `TableLoader` asks each required table's importer to materialize it into
+   DuckDB — normalizing important columns and adding indexes for dates and
+   metric types — and records the loaded state.
 6. Results are cached in memory and returned through the MCP transport.
 
 The process owns one DuckDB database. Nothing is persisted between launches.
 
 ## Components
 
+### Format importers
+
+`src/importers/` holds all ingestion-path format knowledge, one directory per
+format. A `FormatImporter` carries a stable id and display name and exposes
+two operations: `detect` scans the data directory and returns the tables the
+format can produce (canonical lowercase names plus a table kind) without
+materializing anything, and `load` materializes one table into DuckDB,
+returning its row count. `src/importers/simple-csv/` is the only importer
+today and owns the filename regexes and the CSV dialect. Filename suffixes
+such as export dates are removed from the table name during detection.
+
+The registry enforces one format per data directory. When two importers claim
+files in the same scan, the catalog records a typed conflict — surfaced
+through `health_schema` with the fix (split the directories) — and keeps its
+previous state rather than picking a winner.
+
 ### Catalog and lazy loading
 
-`src/db/catalog.ts` recognizes quantity, category, and workout CSV filenames.
-Filename suffixes such as export dates are removed from the table name.
+`src/db/catalog.ts` is format-agnostic: it delegates scanning to the importer
+registry and owns table lifecycle state (loaded, row count, last access).
+Scans commit atomically, and entries whose files disappear are retained.
+Kinds assigned at detection are the only source of table classification —
+`health_report` and `health_schema` select workout tables by kind, never by
+name pattern.
+
 `src/db/loader.ts` finds catalog table names mentioned in a SQL query and
 materializes those tables before execution (`ensureTablesForQuery`).
 
@@ -34,7 +57,7 @@ catalog.
 
 ### Normalization
 
-`src/db/loader.ts` performs these transformations:
+The simple-csv importer's `load` performs these transformations:
 
 - `startDate` and `endDate` become DuckDB timestamps.
 - A quantity row's `value` becomes a number.
@@ -44,6 +67,10 @@ catalog.
 
 Sleep and workout durations should be calculated from the timestamps. Duration
 columns vary between export formats and are not treated as authoritative.
+
+The conformance suite in `src/test-helpers/conformance.ts` asserts this
+contract end-to-end for every importer; a new format adopts it by supplying
+fixtures.
 
 ### Query safety and caching
 
@@ -76,9 +103,9 @@ excluded only when its `startDate` cannot be cast to a timestamp, or when the
 file shape has a `value` column and that value is null.
 
 The load is a single pass: one `CREATE TABLE AS SELECT` reads the CSV straight
-into the typed final table. `TableLoader` sniffs the file's columns with
-`DESCRIBE` first, which samples rather than materializes, so the projection
-matches the quantity, category, or workout shape it was given. Staging raw
+into the typed final table. The simple-csv importer sniffs the file's columns
+with `DESCRIBE` first, which samples rather than materializes, so the
+projection matches the quantity, category, or workout shape it was given. Staging raw
 VARCHAR rows in a separate table beforehand would hold two copies resident and
 roughly double peak memory for a large export.
 
@@ -95,7 +122,10 @@ MCP client and are subject to that client's data handling.
 
 ## Current boundaries
 
-- Simple Health Export CSV is the only ingest format.
+- Simple Health Export CSV is the only registered ingest format; the importer
+  interface exists so Apple Health XML and Health Auto Export can be added
+  without touching the catalog or loader.
+- One export format per data directory.
 - The database is in memory and is rebuilt per process; incremental or
   persistent import is planned future work.
 - Query validation and lazy-load table detection are string-based.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neiltron/apple-health-mcp",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "mcpName": "io.github.neiltron/apple-health-mcp",
   "description": "MCP server for querying Apple Health data with DuckDB",
   "main": "dist/server.js",

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/neiltron/apple-health-mcp",
     "source": "github"
   },
-  "version": "1.4.1",
+  "version": "1.4.2",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@neiltron/apple-health-mcp",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/src/db/catalog.test.ts
+++ b/src/db/catalog.test.ts
@@ -2,7 +2,11 @@ import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { FileCatalog } from './catalog';
+import { FileCatalog, projectTableInfo } from './catalog';
+import { defaultRegistry } from '../importers';
+import { ImporterRegistry, MultipleFormatsError } from '../importers/registry';
+import { SimpleCsvImporter } from '../importers/simple-csv/importer';
+import type { FormatImporter } from '../importers/types';
 import {
   writeCsv,
   formatTimestamp,
@@ -39,7 +43,7 @@ beforeAll(async () => {
   writeFileSync(join(dataDir, 'notes.txt'), 'not health data\n');
   writeCsv(dataDir, 'Workout.csv', WORKOUT_HEADER, [workoutRow('HKWorkoutActivityTypeCycling')]);
 
-  catalog = new FileCatalog(dataDir);
+  catalog = new FileCatalog(dataDir, defaultRegistry());
   await catalog.initialize();
 });
 
@@ -81,7 +85,7 @@ describe('FileCatalog scanning', () => {
       [workoutRow('HKWorkoutActivityTypeCycling')]
     );
 
-    const suffixCatalog = new FileCatalog(suffixDir);
+    const suffixCatalog = new FileCatalog(suffixDir, defaultRegistry());
     await suffixCatalog.initialize();
 
     expect(suffixCatalog.getAllTables()).toContain('hkquantitytypeidentifierheartrate');
@@ -99,7 +103,7 @@ describe('FileCatalog scanning', () => {
 describe('FileCatalog refresh', () => {
   test('picks up a file written after initialize', async () => {
     const lateDir = mkdtempSync(join(tmpdir(), 'health-catalog-late-'));
-    const lateCatalog = new FileCatalog(lateDir);
+    const lateCatalog = new FileCatalog(lateDir, defaultRegistry());
     await lateCatalog.initialize();
     expect(lateCatalog.getAllTables()).toEqual([]);
 
@@ -123,7 +127,7 @@ describe('FileCatalog refresh', () => {
     const goneDir = mkdtempSync(join(tmpdir(), 'health-catalog-gone-'));
     writeCsv(goneDir, 'HKQuantityTypeIdentifierHeartRate.csv', QUANTITY_HEADER, [quantityRow()]);
 
-    const goneCatalog = new FileCatalog(goneDir);
+    const goneCatalog = new FileCatalog(goneDir, defaultRegistry());
     await goneCatalog.initialize();
     goneCatalog.markLoaded('hkquantitytypeidentifierheartrate', 7);
 
@@ -134,5 +138,96 @@ describe('FileCatalog refresh', () => {
     expect(entry?.loaded).toBe(true);
     expect(entry?.rowCount).toBe(7);
     rmSync(goneDir, { recursive: true, force: true });
+  });
+
+  test('resolves duplicate canonical names to the last directory entry', async () => {
+    const dupDir = mkdtempSync(join(tmpdir(), 'health-catalog-dup-'));
+    // Two suffixed exports of the same metric map to one table name.
+    writeCsv(dupDir, 'HKQuantityTypeIdentifierHeartRate_2026-01-01.csv', QUANTITY_HEADER, [
+      quantityRow()
+    ]);
+    writeCsv(dupDir, 'HKQuantityTypeIdentifierHeartRate_2026-07-21.csv', QUANTITY_HEADER, [
+      quantityRow()
+    ]);
+
+    const dupCatalog = new FileCatalog(dupDir, defaultRegistry());
+    await dupCatalog.initialize();
+
+    // readdir order is what the old catalog used; the last entry wins.
+    const { readdirSync } = await import('node:fs');
+    const matching = readdirSync(dupDir).filter((f) => f.endsWith('.csv'));
+    const expected = join(dupDir, matching[matching.length - 1]);
+
+    expect(dupCatalog.getAllTables()).toEqual(['hkquantitytypeidentifierheartrate']);
+    expect(dupCatalog.getTablePath('hkquantitytypeidentifierheartrate')).toBe(expected);
+    rmSync(dupDir, { recursive: true, force: true });
+  });
+});
+
+describe('FileCatalog entry metadata', () => {
+  test('attaches kind and importer to entries', () => {
+    expect(catalog.getEntry('hkquantitytypeidentifierheartrate')?.kind).toBe('quantity');
+    expect(catalog.getEntry('hkworkoutactivitytype')?.kind).toBe('workout');
+    expect(catalog.getEntry('hkworkoutactivitytype')?.importer).toBeDefined();
+  });
+
+  test('projectTableInfo strips path, importer, and kind from serialized output', () => {
+    const projected = projectTableInfo(catalog.getTableInfo());
+
+    expect(projected.length).toBeGreaterThan(0);
+    for (const row of projected) {
+      expect(Object.keys(row).sort()).toEqual(['loaded', 'name', 'rowCount']);
+    }
+    // Sorted by name, matching the health://tables contract.
+    const names = projected.map((row) => row.name);
+    expect(names).toEqual([...names].sort());
+  });
+});
+
+function fakeClaimingImporter(): FormatImporter {
+  return {
+    id: 'fake-json',
+    displayName: 'Fake JSON Export',
+    detect: async () => ({ claimed: true, tables: [] }),
+    load: async () => 0
+  };
+}
+
+describe('FileCatalog multi-format conflict', () => {
+  test('records a typed conflict, keeps the catalog, and clears on a clean scan', async () => {
+    const mixedDir = mkdtempSync(join(tmpdir(), 'health-catalog-mixed-'));
+    writeCsv(mixedDir, 'HKQuantityTypeIdentifierHeartRate.csv', QUANTITY_HEADER, [quantityRow()]);
+
+    const fake = fakeClaimingImporter();
+    let fakeClaims = false;
+    const toggleableFake: FormatImporter = {
+      ...fake,
+      detect: async () => ({ claimed: fakeClaims, tables: [] })
+    };
+    const registry = new ImporterRegistry([new SimpleCsvImporter(), toggleableFake]);
+    const mixedCatalog = new FileCatalog(mixedDir, registry);
+
+    // Clean scan first: catalog populated, no conflict.
+    await mixedCatalog.initialize();
+    expect(mixedCatalog.getScanConflict()).toBeNull();
+    expect(mixedCatalog.getAllTables()).toContain('hkquantitytypeidentifierheartrate');
+
+    // A second format appears: refresh fails, catalog and loaded state kept,
+    // conflict recorded with both display names.
+    mixedCatalog.markLoaded('hkquantitytypeidentifierheartrate', 3);
+    fakeClaims = true;
+    await expect(mixedCatalog.refresh()).rejects.toThrow(MultipleFormatsError);
+
+    const conflict = mixedCatalog.getScanConflict();
+    expect(conflict?.formats).toEqual(['Simple Health Export CSV', 'Fake JSON Export']);
+    expect(conflict?.message).toContain('separate directories');
+    expect(mixedCatalog.getEntry('hkquantitytypeidentifierheartrate')?.loaded).toBe(true);
+
+    // Removing the second format clears the conflict on the next scan.
+    fakeClaims = false;
+    await mixedCatalog.refresh();
+    expect(mixedCatalog.getScanConflict()).toBeNull();
+
+    rmSync(mixedDir, { recursive: true, force: true });
   });
 });

--- a/src/db/catalog.test.ts
+++ b/src/db/catalog.test.ts
@@ -3,26 +3,13 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { FileCatalog } from './catalog';
-
-function formatTimestamp(date: Date): string {
-  return `${date.toISOString().slice(0, 19).replace('T', ' ')} +0000`;
-}
-
-function daysAgo(days: number): Date {
-  const date = new Date();
-  date.setDate(date.getDate() - days);
-  return date;
-}
-
-function writeCsv(dir: string, fileName: string, header: string, rows: string[]): void {
-  const lines = ['sep=,', header, ...rows];
-  writeFileSync(join(dir, fileName), lines.join('\r\n') + '\r\n');
-}
-
-const QUANTITY_HEADER =
-  'type,sourceName,sourceVersion,productType,device,startDate,endDate,unit,value';
-const WORKOUT_HEADER =
-  'type,sourceName,sourceVersion,startDate,endDate,duration,totalEnergyBurned,totalDistance';
+import {
+  writeCsv,
+  formatTimestamp,
+  daysAgo,
+  QUANTITY_HEADER,
+  WORKOUT_HEADER
+} from '../test-helpers/csv-fixtures';
 
 function quantityRow(): string {
   const start = formatTimestamp(daysAgo(1));

--- a/src/db/catalog.test.ts
+++ b/src/db/catalog.test.ts
@@ -199,10 +199,13 @@ describe('FileCatalog multi-format conflict', () => {
     writeCsv(mixedDir, 'HKQuantityTypeIdentifierHeartRate.csv', QUANTITY_HEADER, [quantityRow()]);
 
     const fake = fakeClaimingImporter();
-    let fakeClaims = false;
+    let fakeMode: 'quiet' | 'claim' | 'throw' = 'quiet';
     const toggleableFake: FormatImporter = {
       ...fake,
-      detect: async () => ({ claimed: fakeClaims, tables: [] })
+      detect: async () => {
+        if (fakeMode === 'throw') throw new Error('disk on fire');
+        return { claimed: fakeMode === 'claim', tables: [] };
+      }
     };
     const registry = new ImporterRegistry([new SimpleCsvImporter(), toggleableFake]);
     const mixedCatalog = new FileCatalog(mixedDir, registry);
@@ -215,7 +218,7 @@ describe('FileCatalog multi-format conflict', () => {
     // A second format appears: refresh fails, catalog and loaded state kept,
     // conflict recorded with both display names.
     mixedCatalog.markLoaded('hkquantitytypeidentifierheartrate', 3);
-    fakeClaims = true;
+    fakeMode = 'claim';
     await expect(mixedCatalog.refresh()).rejects.toThrow(MultipleFormatsError);
 
     const conflict = mixedCatalog.getScanConflict();
@@ -223,8 +226,20 @@ describe('FileCatalog multi-format conflict', () => {
     expect(conflict?.message).toContain('separate directories');
     expect(mixedCatalog.getEntry('hkquantitytypeidentifierheartrate')?.loaded).toBe(true);
 
+    // A later scan failure with a different cause supersedes the conflict:
+    // the status reflects the most recent scan outcome, so a fixed conflict
+    // is not still reported while an unrelated failure is the real problem.
+    fakeMode = 'throw';
+    await expect(mixedCatalog.refresh()).rejects.toThrow('Failed to catalog');
+    expect(mixedCatalog.getScanConflict()).toBeNull();
+
+    // A still-present conflict re-records on the next completed detection.
+    fakeMode = 'claim';
+    await expect(mixedCatalog.refresh()).rejects.toThrow(MultipleFormatsError);
+    expect(mixedCatalog.getScanConflict()?.formats).toContain('Fake JSON Export');
+
     // Removing the second format clears the conflict on the next scan.
-    fakeClaims = false;
+    fakeMode = 'quiet';
     await mixedCatalog.refresh();
     expect(mixedCatalog.getScanConflict()).toBeNull();
 

--- a/src/db/catalog.ts
+++ b/src/db/catalog.ts
@@ -1,15 +1,41 @@
-import { readdir } from 'node:fs/promises';
-import { join } from 'node:path';
 import type { CatalogEntry } from '../types';
+import type { ImporterRegistry } from '../importers/registry';
+import { MultipleFormatsError } from '../importers/registry';
+
+// Recorded when a scan finds more than one export format in the data
+// directory. Retained so tools can show the actionable message instead of the
+// generic empty-catalog hint; cleared by the next successful scan.
+export interface ScanConflict {
+  formats: string[];
+  message: string;
+}
+
+// Serialization for the health://tables resource. Catalog entries also hold
+// local file paths and importer references, which stay out of protocol
+// responses; only these fields ever leave the process.
+export function projectTableInfo(
+  info: Record<string, CatalogEntry>
+): Array<{ name: string; loaded: boolean; rowCount: number | null }> {
+  return Object.entries(info)
+    .map(([name, entry]) => ({
+      name,
+      loaded: entry.loaded,
+      rowCount: entry.rowCount
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
 
 export class FileCatalog {
   private catalog: Map<string, CatalogEntry> = new Map();
   private dataDir: string;
-  
-  constructor(dataDir: string) {
+  private registry: ImporterRegistry;
+  private scanConflict: ScanConflict | null = null;
+
+  constructor(dataDir: string, registry: ImporterRegistry) {
     this.dataDir = dataDir;
+    this.registry = registry;
   }
-  
+
   async initialize(): Promise<void> {
     await this.scanDirectory();
   }
@@ -19,52 +45,55 @@ export class FileCatalog {
     await this.scanDirectory();
   }
 
+  getScanConflict(): ScanConflict | null {
+    return this.scanConflict;
+  }
+
   private async scanDirectory(): Promise<void> {
+    // Detection completes before the catalog mutates, so a failed or
+    // conflicting scan leaves the existing catalog untouched.
+    let tables;
     try {
-      const files = await readdir(this.dataDir);
-
-      for (const file of files) {
-        // Workout exports are named HKWorkoutActivityType.csv or
-        // HKWorkoutActivityTypeRunning.csv, with no literal "TypeIdentifier".
-        // The name capture stops at the first non-alphanumeric character, so a
-        // file like HKQuantityTypeIdentifierHeartRate_2026-07-21.csv still maps
-        // to the plain hkquantitytypeidentifierheartrate table name.
-        const match = file.match(/^(HK\w+?TypeIdentifier[A-Za-z0-9]+).*\.csv$/)
-          || file.match(/^(HKWorkoutActivityType[A-Za-z0-9]*).*\.csv$/);
-        if (match) {
-          const tableName = match[1].toLowerCase();
-          const path = join(this.dataDir, file);
-          const existing = this.catalog.get(tableName);
-
-          // Keep loaded state for tables we have already seen at this path.
-          if (existing && existing.path === path) {
-            continue;
-          }
-
-          this.catalog.set(tableName, {
-            path,
-            loaded: false,
-            rowCount: null
-          });
-        }
-      }
-      
-      // console.log(`Found ${this.catalog.size} health data CSV files`);
+      tables = await this.registry.detectAll(this.dataDir);
     } catch (error) {
-      // console.error(`Error scanning directory ${this.dataDir}:`, error);
+      if (error instanceof MultipleFormatsError) {
+        this.scanConflict = { formats: error.formats, message: error.message };
+        throw error;
+      }
       throw new Error(`Failed to catalog health data files: ${error}`);
     }
+
+    this.scanConflict = null;
+
+    for (const table of tables) {
+      const existing = this.catalog.get(table.tableName);
+
+      // Keep loaded state for tables we have already seen at this path.
+      if (existing && existing.path === table.path) {
+        continue;
+      }
+
+      this.catalog.set(table.tableName, {
+        path: table.path,
+        loaded: false,
+        rowCount: null,
+        kind: table.kind,
+        importer: table.importer
+      });
+    }
+    // Entries whose files have disappeared are deliberately retained: loaded
+    // tables stay queryable until evicted.
   }
-  
+
   getTablePath(tableName: string): string | undefined {
     const entry = this.catalog.get(tableName.toLowerCase());
     return entry?.path;
   }
-  
+
   getEntry(tableName: string): CatalogEntry | undefined {
     return this.catalog.get(tableName.toLowerCase());
   }
-  
+
   markLoaded(tableName: string, rowCount: number): void {
     const entry = this.catalog.get(tableName.toLowerCase());
     if (entry) {
@@ -73,20 +102,20 @@ export class FileCatalog {
       entry.lastAccessed = new Date();
     }
   }
-  
+
   markUnloaded(tableName: string): void {
     const entry = this.catalog.get(tableName.toLowerCase());
     if (entry) {
       entry.loaded = false;
     }
   }
-  
+
   getLoadedTables(): string[] {
     return Array.from(this.catalog.entries())
       .filter(([_, entry]) => entry.loaded)
       .map(([name]) => name);
   }
-  
+
   getTablesByLastAccess(): string[] {
     return Array.from(this.catalog.entries())
       .filter(([_, entry]) => entry.loaded)
@@ -97,11 +126,11 @@ export class FileCatalog {
       })
       .map(([name]) => name);
   }
-  
+
   getAllTables(): string[] {
     return Array.from(this.catalog.keys());
   }
-  
+
   getTableInfo(): Record<string, CatalogEntry> {
     const info: Record<string, CatalogEntry> = {};
     for (const [name, entry] of this.catalog) {

--- a/src/db/catalog.ts
+++ b/src/db/catalog.ts
@@ -1,5 +1,6 @@
 import type { CatalogEntry } from '../types';
 import type { ImporterRegistry } from '../importers/registry';
+import type { TableKind } from '../importers/types';
 import { MultipleFormatsError } from '../importers/registry';
 
 // Recorded when a scan finds more than one export format in the data
@@ -129,6 +130,14 @@ export class FileCatalog {
 
   getAllTables(): string[] {
     return Array.from(this.catalog.keys());
+  }
+
+  // The one place table classification lives: kinds come from detection, so
+  // tools never pattern-match table names.
+  getTablesByKind(kind: TableKind): string[] {
+    return Array.from(this.catalog.entries())
+      .filter(([_, entry]) => entry.kind === kind)
+      .map(([name]) => name);
   }
 
   getTableInfo(): Record<string, CatalogEntry> {

--- a/src/db/catalog.ts
+++ b/src/db/catalog.ts
@@ -61,6 +61,11 @@ export class FileCatalog {
         this.scanConflict = { formats: error.formats, message: error.message };
         throw error;
       }
+      // A non-conflict failure supersedes any recorded conflict: the status
+      // always reflects the most recent scan outcome. Clearing is non-lossy —
+      // a conflict that still exists re-records on the next completed
+      // detection.
+      this.scanConflict = null;
       throw new Error(`Failed to catalog health data files: ${error}`);
     }
 

--- a/src/db/loader.test.ts
+++ b/src/db/loader.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { HealthDataDB } from './database';
 import { FileCatalog } from './catalog';
+import { defaultRegistry } from '../importers';
 import { TableLoader } from './loader';
 import {
   writeCsv,
@@ -195,7 +196,7 @@ beforeAll(async () => {
 
   db = new HealthDataDB({ dataDir, maxMemoryMB: 512 });
   await db.initialize();
-  catalog = new FileCatalog(dataDir);
+  catalog = new FileCatalog(dataDir, defaultRegistry());
   await catalog.initialize();
   loader = new TableLoader(db, catalog);
 });
@@ -454,7 +455,7 @@ describe('TableLoader path handling', () => {
 
     const quotedDb = new HealthDataDB({ dataDir: quotedDir, maxMemoryMB: 512 });
     await quotedDb.initialize();
-    const quotedCatalog = new FileCatalog(quotedDir);
+    const quotedCatalog = new FileCatalog(quotedDir, defaultRegistry());
     await quotedCatalog.initialize();
     const quotedLoader = new TableLoader(quotedDb, quotedCatalog);
 
@@ -511,7 +512,7 @@ describe('TableLoader load mechanics', () => {
   beforeAll(async () => {
     spyDb = new HealthDataDB({ dataDir, maxMemoryMB: 512 });
     await spyDb.initialize();
-    spyCatalog = new FileCatalog(dataDir);
+    spyCatalog = new FileCatalog(dataDir, defaultRegistry());
     await spyCatalog.initialize();
     spyLoader = new TableLoader(spyDb, spyCatalog);
 

--- a/src/db/loader.test.ts
+++ b/src/db/loader.test.ts
@@ -5,6 +5,13 @@ import { join } from 'node:path';
 import { HealthDataDB } from './database';
 import { FileCatalog } from './catalog';
 import { TableLoader } from './loader';
+import {
+  writeCsv,
+  formatTimestamp,
+  daysAfter,
+  QUANTITY_HEADER,
+  CATEGORY_HEADER
+} from '../test-helpers/csv-fixtures';
 
 const RECENT_ROWS = 120;
 const OLD_ROWS = 5;
@@ -20,26 +27,6 @@ const DRIFT_TEXT_ROWS = 500;
 // wall-clock window would fail these tests, not just a 90-day one.
 const RECENT_ANCHOR = new Date('2020-06-01T00:00:00Z');
 const OLD_ANCHOR = new Date('2010-01-15T00:00:00Z');
-
-function formatTimestamp(date: Date): string {
-  return `${date.toISOString().slice(0, 19).replace('T', ' ')} +0000`;
-}
-
-function daysAfter(anchor: Date, days: number): Date {
-  const date = new Date(anchor);
-  date.setDate(date.getDate() + days);
-  return date;
-}
-
-function writeCsv(dir: string, fileName: string, header: string, rows: string[]): void {
-  const lines = ['sep=,', header, ...rows];
-  writeFileSync(join(dir, fileName), lines.join('\r\n') + '\r\n');
-}
-
-const QUANTITY_HEADER =
-  'type,sourceName,sourceVersion,productType,device,startDate,endDate,unit,value';
-const CATEGORY_HEADER =
-  'type,sourceName,sourceVersion,productType,device,startDate,endDate,value';
 
 function quantityRow(start: string, value: number): string {
   return `HKQuantityTypeIdentifierHeartRate,Apple Watch,10.0,Watch7,1,${start},${start},count/min,${value}`;

--- a/src/db/loader.ts
+++ b/src/db/loader.ts
@@ -1,5 +1,6 @@
 import type { HealthDataDB } from './database';
 import type { FileCatalog } from './catalog';
+import type { CatalogEntry } from '../types';
 
 export class TableLoader {
   private db: HealthDataDB;
@@ -9,34 +10,38 @@ export class TableLoader {
     this.db = db;
     this.catalog = catalog;
   }
-  
+
   async ensureTableLoaded(tableName: string): Promise<void> {
     const entry = this.catalog.getEntry(tableName);
     if (!entry) {
       throw new Error(`Table ${tableName} not found in catalog`);
     }
-    
+
     if (entry.loaded) {
       entry.lastAccessed = new Date();
       return;
     }
-    
-    await this.loadTable(tableName, entry.path);
-  }
-  
-  private async loadTable(tableName: string, filePath: string): Promise<void> {
-    try {
-      await this.cleanAndOptimizeTable(filePath, tableName);
 
-      // Count the final table: the load also drops rows with a null value, so
-      // the catalog count matches what is actually stored. A file with no
-      // readable rows still produces an empty table and is still marked loaded,
-      // so queries return zero rows instead of a missing-table error and the
-      // CSV is not rescanned on every request.
-      const countResult = await this.db.execute(
-        `SELECT COUNT(*) as count FROM ${tableName}`
-      );
-      const rowCount = Number(countResult[0]?.count ?? 0);
+    await this.loadTable(tableName, entry);
+  }
+
+  private async loadTable(tableName: string, entry: CatalogEntry): Promise<void> {
+    const importer = entry.importer;
+    if (!importer) {
+      throw new Error(`Table ${tableName} has no importer in the catalog`);
+    }
+
+    try {
+      // The importer owns materialization and returns the stored row count;
+      // the loader owns lifecycle state. A file with no readable rows still
+      // produces an empty table and is still marked loaded, so queries return
+      // zero rows instead of a missing-table error and the source is not
+      // rescanned on every request.
+      const rowCount = await importer.load(this.db, {
+        tableName,
+        path: entry.path,
+        kind: entry.kind ?? 'other'
+      });
       this.catalog.markLoaded(tableName, rowCount);
     } catch (error) {
       // Clean up on error. There is no staging table, so the partially created
@@ -46,137 +51,27 @@ export class TableLoader {
     }
   }
 
-  // Column names come from CSV headers, and real exports contain metadata
-  // columns with spaces, e.g. "Health Mate App Version" from Withings. Every
-  // identifier taken from a header must be quoted.
-  private quoteIdent(name: string): string {
-    return `"${name.replace(/"/g, '""')}"`;
-  }
-
-  private csvSource(filePath: string): string {
-    // Paths are not user queries, but a directory name like "Neil's Health"
-    // contains a quote that would end the SQL literal early.
-    const escapedPath = filePath.replace(/'/g, "''");
-    // sample_size = -1 sniffs column types from the whole file, not the first
-    // ~20k rows. Metadata columns like sourceVersion look numeric for months
-    // ("10.5") and then stop ("11.0.1"); a sampled DOUBLE guess turns every
-    // later row into a CAST error that ignore_errors silently drops.
-    return `read_csv('${escapedPath}',
-        header = true,
-        skip = 1,
-        delim = ',',
-        quote = '"',
-        escape = '"',
-        ignore_errors = true,
-        null_padding = true,
-        new_line = '\\r\\n',
-        sample_size = -1
-      )`;
-  }
-
-  private async cleanAndOptimizeTable(filePath: string, finalTable: string): Promise<void> {
-    // Drop existing table if it exists
-    await this.db.run(`DROP TABLE IF EXISTS ${finalTable}`);
-
-    const source = this.csvSource(filePath);
-
-    // Health exports come in several shapes. Quantity CSVs have unit and value,
-    // category CSVs have no unit, workout CSVs have neither and carry duration
-    // and energy columns instead. Sniff the columns first so the projection is
-    // built from the columns that are actually present and every shape loads.
-    // DESCRIBE only samples the file; it materializes no rows.
-    const describedColumns = await this.db.execute(`DESCRIBE SELECT * FROM ${source}`);
-    const columnNames: string[] = describedColumns.map((col: any) => col.column_name);
-    const columnByLower = new Map<string, string>();
-    for (const name of columnNames) {
-      columnByLower.set(name.toLowerCase(), name);
-    }
-
-    const startDateCol = columnByLower.get('startdate');
-    const valueCol = columnByLower.get('value');
-    const typeCol = columnByLower.get('type');
-
-    // Every consumer sorts and filters on startDate. A CSV without that column
-    // is not a loadable health export; fail here with a clear reason instead of
-    // materializing a table that breaks every downstream query.
-    if (!startDateCol) {
-      throw new Error(`CSV has no startDate column: ${filePath}`);
-    }
-
-    const selectParts: string[] = [];
-    for (const name of columnNames) {
-      const lower = name.toLowerCase();
-      const ident = this.quoteIdent(name);
-      if (lower === 'startdate' || lower === 'enddate') {
-        selectParts.push(`TRY_CAST(SUBSTR(${ident}, 1, 19) AS TIMESTAMP) as ${ident}`);
-      } else if (lower === 'value') {
-        // Category rows hold text labels like HKCategoryValueSleepAnalysisAsleepCore.
-        // Keep the numeric cast for quantity queries and keep the raw label in valueText.
-        selectParts.push(`TRY_CAST(${ident} AS DOUBLE) as ${ident}`);
-        selectParts.push(`CAST(${ident} AS VARCHAR) as valueText`);
-      } else {
-        selectParts.push(ident);
-      }
-    }
-
-    // Keep every row whose startDate can become a timestamp. There is no
-    // history window; an invalid startDate, and a null value where the shape
-    // has a value column, are the only exclusions.
-    const conditions: string[] = [
-      `TRY_CAST(SUBSTR(${this.quoteIdent(startDateCol)}, 1, 19) AS TIMESTAMP) IS NOT NULL`,
-    ];
-    if (valueCol) {
-      conditions.push(`${this.quoteIdent(valueCol)} IS NOT NULL`);
-    }
-    const whereClause = `\n      WHERE ${conditions.join('\n        AND ')}`;
-
-    // One pass from CSV straight into the typed final table. Staging the raw
-    // rows first would hold both copies resident and roughly double peak memory
-    // for a large export.
-    await this.db.run(`
-      CREATE TABLE ${finalTable} AS
-      SELECT
-        ${selectParts.join(',\n        ')}
-      FROM ${source}${whereClause}
-    `);
-
-    // Create indexes for common query patterns
-    await this.db.run(`
-      CREATE INDEX IF NOT EXISTS idx_${finalTable}_startdate
-      ON ${finalTable}(${this.quoteIdent(startDateCol)})
-    `);
-
-    if (typeCol) {
-      await this.db.run(`
-        CREATE INDEX IF NOT EXISTS idx_${finalTable}_type
-        ON ${finalTable}(${this.quoteIdent(typeCol)})
-      `);
-    }
-  }
-  
   async loadAllTables(): Promise<void> {
     const tables = this.catalog.getAllTables();
-    // console.log(`Loading ${tables.length} tables...`);
-    
+
     for (const table of tables) {
       try {
         await this.ensureTableLoaded(table);
       } catch (error) {
-        // console.error(`Failed to load ${table}:`, error);
+        // A single unreadable file must not stop the rest of the export.
       }
     }
   }
-  
+
   async unloadTable(tableName: string): Promise<void> {
     try {
       await this.db.run(`DROP TABLE IF EXISTS ${tableName}`);
       this.catalog.markUnloaded(tableName);
-      // console.log(`Unloaded table ${tableName}`);
     } catch (error) {
-      // console.error(`Failed to unload ${tableName}:`, error);
+      // Eviction is best-effort; a failed drop leaves the table queryable.
     }
   }
-  
+
   // Queries run against lazily loaded tables, so every table a query touches
   // must be materialized before execution.
   async ensureTablesForQuery(query: string): Promise<void> {
@@ -189,7 +84,7 @@ export class TableLoader {
   extractTableNames(query: string): string[] {
     const tables = new Set<string>();
     const allTables = this.catalog.getAllTables();
-    
+
     // Simple regex to find table names in query
     const queryLower = query.toLowerCase();
     for (const table of allTables) {
@@ -197,7 +92,7 @@ export class TableLoader {
         tables.add(table);
       }
     }
-    
+
     return Array.from(tables);
   }
 }

--- a/src/importers/index.ts
+++ b/src/importers/index.ts
@@ -1,0 +1,6 @@
+import { ImporterRegistry } from './registry';
+import { SimpleCsvImporter } from './simple-csv/importer';
+
+export function defaultRegistry(): ImporterRegistry {
+  return new ImporterRegistry([new SimpleCsvImporter()]);
+}

--- a/src/importers/registry.test.ts
+++ b/src/importers/registry.test.ts
@@ -1,0 +1,95 @@
+import { describe, test, expect } from 'bun:test';
+import { ImporterRegistry, MultipleFormatsError } from './registry';
+import type { DetectionResult, FormatImporter } from './types';
+
+function fakeImporter(
+  id: string,
+  displayName: string,
+  result: DetectionResult
+): FormatImporter {
+  return {
+    id,
+    displayName,
+    detect: async () => result,
+    load: async () => 0
+  };
+}
+
+describe('ImporterRegistry', () => {
+  test('returns the claiming importer tables with the importer attached', async () => {
+    const importer = fakeImporter('fake-csv', 'Fake CSV', {
+      claimed: true,
+      tables: [
+        { tableName: 'hkquantitytypeidentifierheartrate', path: '/data/a.csv', kind: 'quantity' },
+        { tableName: 'hkworkoutactivitytype', path: '/data/b.csv', kind: 'workout' }
+      ]
+    });
+    const registry = new ImporterRegistry([importer]);
+
+    const tables = await registry.detectAll('/data');
+
+    expect(tables.length).toBe(2);
+    expect(tables[0].tableName).toBe('hkquantitytypeidentifierheartrate');
+    expect(tables[0].importer).toBe(importer);
+    expect(tables[1].importer).toBe(importer);
+  });
+
+  test('no claiming importer yields an empty result without error', async () => {
+    const importer = fakeImporter('fake-csv', 'Fake CSV', { claimed: false, tables: [] });
+    const registry = new ImporterRegistry([importer]);
+
+    expect(await registry.detectAll('/data')).toEqual([]);
+  });
+
+  test('a claimed format with zero tables still claims the directory', async () => {
+    const empty = fakeImporter('fake-empty', 'Fake Empty', { claimed: true, tables: [] });
+    const other = fakeImporter('fake-other', 'Fake Other', {
+      claimed: true,
+      tables: [{ tableName: 'hkquantitytypeidentifiersteps', path: '/data/s.csv', kind: 'quantity' }]
+    });
+
+    // Alone, an empty claim yields an empty catalog without error.
+    expect(await new ImporterRegistry([empty]).detectAll('/data')).toEqual([]);
+
+    // Combined with a second claiming format, it still counts as a conflict.
+    await expect(new ImporterRegistry([empty, other]).detectAll('/data')).rejects.toThrow(
+      MultipleFormatsError
+    );
+  });
+
+  test('two claiming formats produce an error naming both display names', async () => {
+    const a = fakeImporter('format-a', 'Format A', {
+      claimed: true,
+      tables: [{ tableName: 'hkquantitytypeidentifiersteps', path: '/data/a.csv', kind: 'quantity' }]
+    });
+    const b = fakeImporter('format-b', 'Format B', {
+      claimed: true,
+      tables: [{ tableName: 'hkquantitytypeidentifiermass', path: '/data/b.json', kind: 'quantity' }]
+    });
+
+    const error = await new ImporterRegistry([a, b])
+      .detectAll('/data')
+      .then(() => null)
+      .catch((err: Error) => err);
+
+    expect(error).toBeInstanceOf(MultipleFormatsError);
+    expect(error!.message).toContain('Format A');
+    expect(error!.message).toContain('Format B');
+    expect(error!.message).toContain('separate directories');
+  });
+
+  test('a detect that throws propagates as a scan failure', async () => {
+    const broken: FormatImporter = {
+      id: 'broken',
+      displayName: 'Broken',
+      detect: async () => {
+        throw new Error('permission denied');
+      },
+      load: async () => 0
+    };
+
+    await expect(new ImporterRegistry([broken]).detectAll('/data')).rejects.toThrow(
+      'permission denied'
+    );
+  });
+});

--- a/src/importers/registry.ts
+++ b/src/importers/registry.ts
@@ -1,0 +1,52 @@
+import type { DetectedTable, FormatImporter } from './types';
+
+export interface ClaimedTable extends DetectedTable {
+  importer: FormatImporter;
+}
+
+export class MultipleFormatsError extends Error {
+  constructor(displayNames: string[]) {
+    super(
+      `Multiple export formats found in the data directory: ${displayNames.join(', ')}. ` +
+        `Use one format per directory — split the exports into separate directories ` +
+        `and point HEALTH_DATA_DIR at one of them.`
+    );
+    this.name = 'MultipleFormatsError';
+  }
+}
+
+export class ImporterRegistry {
+  private importers: FormatImporter[];
+
+  constructor(importers: FormatImporter[]) {
+    this.importers = importers;
+  }
+
+  // Runs every importer's detect and enforces the one-format-per-directory
+  // rule. A format claims the directory when its files are present, even with
+  // zero resulting tables. Returns the claiming format's tables with the
+  // owning importer attached; importers themselves stay unaware of the
+  // registry. Table order preserves each importer's directory iteration order
+  // so duplicate canonical names keep last-entry-wins semantics downstream.
+  async detectAll(dataDir: string): Promise<ClaimedTable[]> {
+    const claims: Array<{ importer: FormatImporter; tables: DetectedTable[] }> = [];
+
+    for (const importer of this.importers) {
+      const result = await importer.detect(dataDir);
+      if (result.claimed) {
+        claims.push({ importer, tables: result.tables });
+      }
+    }
+
+    if (claims.length > 1) {
+      throw new MultipleFormatsError(claims.map((claim) => claim.importer.displayName));
+    }
+
+    const claim = claims[0];
+    if (!claim) {
+      return [];
+    }
+
+    return claim.tables.map((table) => ({ ...table, importer: claim.importer }));
+  }
+}

--- a/src/importers/registry.ts
+++ b/src/importers/registry.ts
@@ -5,6 +5,8 @@ export interface ClaimedTable extends DetectedTable {
 }
 
 export class MultipleFormatsError extends Error {
+  readonly formats: string[];
+
   constructor(displayNames: string[]) {
     super(
       `Multiple export formats found in the data directory: ${displayNames.join(', ')}. ` +
@@ -12,6 +14,7 @@ export class MultipleFormatsError extends Error {
         `and point HEALTH_DATA_DIR at one of them.`
     );
     this.name = 'MultipleFormatsError';
+    this.formats = displayNames;
   }
 }
 

--- a/src/importers/simple-csv/conformance.test.ts
+++ b/src/importers/simple-csv/conformance.test.ts
@@ -1,0 +1,78 @@
+import { runFormatConformance, type ConformanceExpectations } from '../../test-helpers/conformance';
+import { SimpleCsvImporter } from './importer';
+import {
+  writeCsv,
+  formatTimestamp,
+  QUANTITY_HEADER,
+  CATEGORY_HEADER,
+  WORKOUT_HEADER
+} from '../../test-helpers/csv-fixtures';
+
+const VALID_ROWS = 6;
+const OLD_ROW_YEAR = 2009;
+const WORKOUT_SECONDS = 45 * 60;
+
+function quantityRow(start: string, end: string, value: string): string {
+  return `HKQuantityTypeIdentifierHeartRate,Apple Watch,10.0,Watch7,1,${start},${end},count/min,${value}`;
+}
+
+function writeFixtures(dir: string): ConformanceExpectations {
+  const stamp = (iso: string) => formatTimestamp(new Date(iso));
+
+  const rows: string[] = [];
+  for (let i = 0; i < VALID_ROWS - 1; i++) {
+    const at = stamp(`2020-06-0${i + 1}T10:00:00Z`);
+    rows.push(quantityRow(at, at, String(60 + i)));
+  }
+  // The decades-old row proves there is no date window.
+  const old = stamp(`${OLD_ROW_YEAR}-03-15T08:00:00Z`);
+  rows.push(quantityRow(old, old, '55'));
+  // Non-numeric value: loads with numeric NULL, text preserved.
+  const at = stamp('2020-06-20T10:00:00Z');
+  rows.push(quantityRow(at, at, 'not-a-number'));
+  // Unparseable startDate: excluded.
+  rows.push(quantityRow('never oclock', at, '70'));
+  // Empty value where the shape has a value column: excluded.
+  rows.push(quantityRow(at, at, ''));
+  // Unparseable endDate: still loads, endDate NULL.
+  rows.push(quantityRow(stamp('2020-06-21T10:00:00Z'), 'never oclock', '71'));
+  writeCsv(dir, 'HKQuantityTypeIdentifierHeartRate.csv', QUANTITY_HEADER, rows);
+
+  const sleepAt = stamp('2020-06-01T00:30:00Z');
+  const sleepEnd = stamp('2020-06-01T04:30:00Z');
+  writeCsv(dir, 'HKCategoryTypeIdentifierSleepAnalysis.csv', CATEGORY_HEADER, [
+    `HKCategoryTypeIdentifierSleepAnalysis,Apple Watch,10.0,Watch7,1,${sleepAt},${sleepEnd},HKCategoryValueSleepAnalysisAsleepCore`
+  ]);
+
+  const workoutStart = stamp('2020-06-02T17:00:00Z');
+  const workoutEnd = stamp('2020-06-02T17:45:00Z');
+  writeCsv(dir, 'HKWorkoutActivityTypeRunning.csv', WORKOUT_HEADER, [
+    `HKWorkoutActivityTypeRunning,Apple Watch,10.0,${workoutStart},${workoutEnd},45,400,5.5`
+  ]);
+
+  // Every row has an unparseable startDate, so nothing survives the load.
+  writeCsv(dir, 'HKQuantityTypeIdentifierStepCount.csv', QUANTITY_HEADER, [
+    quantityRow('not-a-date', 'not-a-date', '7000')
+  ]);
+
+  // No startDate column at all: the load must fail and leave nothing behind.
+  writeCsv(dir, 'HKQuantityTypeIdentifierBodyMass.csv', 'type,when,value', [
+    'HKQuantityTypeIdentifierBodyMass,yesterday,80'
+  ]);
+
+  return {
+    quantityTable: 'hkquantitytypeidentifierheartrate',
+    validRows: VALID_ROWS,
+    oldRowYear: OLD_ROW_YEAR,
+    nonNumericValueText: 'not-a-number',
+    categoryTable: 'hkcategorytypeidentifiersleepanalysis',
+    categoryLabel: 'HKCategoryValueSleepAnalysisAsleepCore',
+    workoutTable: 'hkworkoutactivitytyperunning',
+    workoutColumn: 'totalEnergyBurned',
+    workoutDurationSeconds: WORKOUT_SECONDS,
+    emptyTable: 'hkquantitytypeidentifierstepcount',
+    brokenTable: 'hkquantitytypeidentifierbodymass'
+  };
+}
+
+runFormatConformance(new SimpleCsvImporter(), writeFixtures);

--- a/src/importers/simple-csv/importer.test.ts
+++ b/src/importers/simple-csv/importer.test.ts
@@ -1,0 +1,67 @@
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { SimpleCsvImporter } from './importer';
+import { writeCsv, QUANTITY_HEADER, WORKOUT_HEADER } from '../../test-helpers/csv-fixtures';
+
+let dataDir: string;
+const importer = new SimpleCsvImporter();
+
+beforeAll(() => {
+  dataDir = mkdtempSync(join(tmpdir(), 'simple-csv-detect-'));
+
+  writeCsv(dataDir, 'HKQuantityTypeIdentifierHeartRate_2026-07-21.csv', QUANTITY_HEADER, []);
+  writeCsv(dataDir, 'HKCategoryTypeIdentifierSleepAnalysis.csv', QUANTITY_HEADER, []);
+  writeCsv(dataDir, 'HKWorkoutActivityType.csv', WORKOUT_HEADER, []);
+  writeCsv(dataDir, 'HKWorkoutActivityTypeRunning.csv', WORKOUT_HEADER, []);
+  // Recognized by the regex but not a family the loader has verified.
+  writeCsv(dataDir, 'HKWorkoutTypeIdentifierTest.csv', WORKOUT_HEADER, []);
+  // Not health exports.
+  writeFileSync(join(dataDir, 'notes.txt'), 'not health data\n');
+  writeCsv(dataDir, 'Workout.csv', WORKOUT_HEADER, []);
+});
+
+afterAll(() => {
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe('SimpleCsvImporter detect', () => {
+  test('maps filenames to the same canonical table names the catalog produced', async () => {
+    const result = await importer.detect(dataDir);
+    const names = result.tables.map((t) => t.tableName).sort();
+
+    expect(result.claimed).toBe(true);
+    expect(names).toEqual([
+      'hkcategorytypeidentifiersleepanalysis',
+      'hkquantitytypeidentifierheartrate',
+      'hkworkoutactivitytype',
+      'hkworkoutactivitytyperunning',
+      'hkworkouttypeidentifiertest'
+    ]);
+  });
+
+  test('assigns kinds from the filename family', async () => {
+    const result = await importer.detect(dataDir);
+    const kinds = new Map(result.tables.map((t) => [t.tableName, t.kind]));
+
+    expect(kinds.get('hkquantitytypeidentifierheartrate')).toBe('quantity');
+    expect(kinds.get('hkcategorytypeidentifiersleepanalysis')).toBe('category');
+    expect(kinds.get('hkworkoutactivitytype')).toBe('workout');
+    expect(kinds.get('hkworkoutactivitytyperunning')).toBe('workout');
+    // An unverified identifier family must not assert a shape.
+    expect(kinds.get('hkworkouttypeidentifiertest')).toBe('other');
+  });
+
+  test('does not claim a directory with no recognized files', async () => {
+    const emptyDir = mkdtempSync(join(tmpdir(), 'simple-csv-empty-'));
+    try {
+      writeFileSync(join(emptyDir, 'readme.md'), 'nothing here\n');
+      const result = await importer.detect(emptyDir);
+      expect(result.claimed).toBe(false);
+      expect(result.tables).toEqual([]);
+    } finally {
+      rmSync(emptyDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/importers/simple-csv/importer.ts
+++ b/src/importers/simple-csv/importer.ts
@@ -1,0 +1,173 @@
+import { readdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import type { HealthDataDB } from '../../db/database';
+import type { DetectedTable, DetectionResult, FormatImporter, TableKind } from '../types';
+
+// Kind comes from the filename alone; detection reads no rows. Families the
+// regex admits but the loader has never verified (e.g. HKWorkoutTypeIdentifier*)
+// stay `other` rather than asserting a shape.
+function kindForFile(fileName: string): TableKind {
+  if (fileName.startsWith('HKWorkoutActivityType')) return 'workout';
+  if (fileName.startsWith('HKCategoryTypeIdentifier')) return 'category';
+  if (fileName.startsWith('HKQuantityTypeIdentifier')) return 'quantity';
+  return 'other';
+}
+
+export class SimpleCsvImporter implements FormatImporter {
+  readonly id = 'simple-health-export-csv';
+  readonly displayName = 'Simple Health Export CSV';
+
+  // Directory iteration order is preserved so duplicate canonical names keep
+  // the catalog's last-entry-wins behavior.
+  async detect(dataDir: string): Promise<DetectionResult> {
+    const files = await readdir(dataDir);
+    const tables: DetectedTable[] = [];
+
+    for (const file of files) {
+      // Workout exports are named HKWorkoutActivityType.csv or
+      // HKWorkoutActivityTypeRunning.csv, with no literal "TypeIdentifier".
+      // The name capture stops at the first non-alphanumeric character, so a
+      // file like HKQuantityTypeIdentifierHeartRate_2026-07-21.csv still maps
+      // to the plain hkquantitytypeidentifierheartrate table name.
+      const match = file.match(/^(HK\w+?TypeIdentifier[A-Za-z0-9]+).*\.csv$/)
+        || file.match(/^(HKWorkoutActivityType[A-Za-z0-9]*).*\.csv$/);
+      if (!match) {
+        continue;
+      }
+
+      tables.push({
+        tableName: match[1].toLowerCase(),
+        path: join(dataDir, file),
+        kind: kindForFile(file)
+      });
+    }
+
+    return { claimed: tables.length > 0, tables };
+  }
+
+  async load(db: HealthDataDB, table: DetectedTable): Promise<number> {
+    await this.cleanAndOptimizeTable(db, table.path, table.tableName);
+
+    // Count the final table: the load also drops rows with a null value, so
+    // the recorded count matches what is actually stored. A file with no
+    // readable rows still produces an empty table, so queries return zero rows
+    // instead of a missing-table error and the CSV is not rescanned on every
+    // request.
+    const countResult = await db.execute(
+      `SELECT COUNT(*) as count FROM ${table.tableName}`
+    );
+    return Number(countResult[0]?.count ?? 0);
+  }
+
+  // Column names come from CSV headers, and real exports contain metadata
+  // columns with spaces, e.g. "Health Mate App Version" from Withings. Every
+  // identifier taken from a header must be quoted.
+  private quoteIdent(name: string): string {
+    return `"${name.replace(/"/g, '""')}"`;
+  }
+
+  private csvSource(filePath: string): string {
+    // Paths are not user queries, but a directory name like "Neil's Health"
+    // contains a quote that would end the SQL literal early.
+    const escapedPath = filePath.replace(/'/g, "''");
+    // sample_size = -1 sniffs column types from the whole file, not the first
+    // ~20k rows. Metadata columns like sourceVersion look numeric for months
+    // ("10.5") and then stop ("11.0.1"); a sampled DOUBLE guess turns every
+    // later row into a CAST error that ignore_errors silently drops.
+    return `read_csv('${escapedPath}',
+        header = true,
+        skip = 1,
+        delim = ',',
+        quote = '"',
+        escape = '"',
+        ignore_errors = true,
+        null_padding = true,
+        new_line = '\\r\\n',
+        sample_size = -1
+      )`;
+  }
+
+  private async cleanAndOptimizeTable(
+    db: HealthDataDB,
+    filePath: string,
+    finalTable: string
+  ): Promise<void> {
+    // Drop existing table if it exists
+    await db.run(`DROP TABLE IF EXISTS ${finalTable}`);
+
+    const source = this.csvSource(filePath);
+
+    // Health exports come in several shapes. Quantity CSVs have unit and value,
+    // category CSVs have no unit, workout CSVs have neither and carry duration
+    // and energy columns instead. Sniff the columns first so the projection is
+    // built from the columns that are actually present and every shape loads.
+    // DESCRIBE only samples the file; it materializes no rows.
+    const describedColumns = await db.execute(`DESCRIBE SELECT * FROM ${source}`);
+    const columnNames: string[] = describedColumns.map((col: any) => col.column_name);
+    const columnByLower = new Map<string, string>();
+    for (const name of columnNames) {
+      columnByLower.set(name.toLowerCase(), name);
+    }
+
+    const startDateCol = columnByLower.get('startdate');
+    const valueCol = columnByLower.get('value');
+    const typeCol = columnByLower.get('type');
+
+    // Every consumer sorts and filters on startDate. A CSV without that column
+    // is not a loadable health export; fail here with a clear reason instead of
+    // materializing a table that breaks every downstream query.
+    if (!startDateCol) {
+      throw new Error(`CSV has no startDate column: ${filePath}`);
+    }
+
+    const selectParts: string[] = [];
+    for (const name of columnNames) {
+      const lower = name.toLowerCase();
+      const ident = this.quoteIdent(name);
+      if (lower === 'startdate' || lower === 'enddate') {
+        selectParts.push(`TRY_CAST(SUBSTR(${ident}, 1, 19) AS TIMESTAMP) as ${ident}`);
+      } else if (lower === 'value') {
+        // Category rows hold text labels like HKCategoryValueSleepAnalysisAsleepCore.
+        // Keep the numeric cast for quantity queries and keep the raw label in valueText.
+        selectParts.push(`TRY_CAST(${ident} AS DOUBLE) as ${ident}`);
+        selectParts.push(`CAST(${ident} AS VARCHAR) as valueText`);
+      } else {
+        selectParts.push(ident);
+      }
+    }
+
+    // Keep every row whose startDate can become a timestamp. There is no
+    // history window; an invalid startDate, and a null value where the shape
+    // has a value column, are the only exclusions.
+    const conditions: string[] = [
+      `TRY_CAST(SUBSTR(${this.quoteIdent(startDateCol)}, 1, 19) AS TIMESTAMP) IS NOT NULL`,
+    ];
+    if (valueCol) {
+      conditions.push(`${this.quoteIdent(valueCol)} IS NOT NULL`);
+    }
+    const whereClause = `\n      WHERE ${conditions.join('\n        AND ')}`;
+
+    // One pass from CSV straight into the typed final table. Staging the raw
+    // rows first would hold both copies resident and roughly double peak memory
+    // for a large export.
+    await db.run(`
+      CREATE TABLE ${finalTable} AS
+      SELECT
+        ${selectParts.join(',\n        ')}
+      FROM ${source}${whereClause}
+    `);
+
+    // Create indexes for common query patterns
+    await db.run(`
+      CREATE INDEX IF NOT EXISTS idx_${finalTable}_startdate
+      ON ${finalTable}(${this.quoteIdent(startDateCol)})
+    `);
+
+    if (typeCol) {
+      await db.run(`
+        CREATE INDEX IF NOT EXISTS idx_${finalTable}_type
+        ON ${finalTable}(${this.quoteIdent(typeCol)})
+      `);
+    }
+  }
+}

--- a/src/importers/types.ts
+++ b/src/importers/types.ts
@@ -1,0 +1,31 @@
+import type { HealthDataDB } from '../db/database';
+
+// Classification assigned at detection from the filename alone. `other` covers
+// recognized identifier families whose row shape detection has not verified
+// (e.g. HKWorkoutTypeIdentifier*); a kind must never assert a shape it hasn't
+// seen.
+export type TableKind = 'quantity' | 'category' | 'workout' | 'other';
+
+export interface DetectedTable {
+  // Canonical lowercase HK identifier, e.g. hkquantitytypeidentifierheartrate.
+  tableName: string;
+  path: string;
+  kind: TableKind;
+}
+
+export interface DetectionResult {
+  // True whenever this format's files are present, even if they yield zero
+  // tables, so an empty-but-recognized export still claims its format.
+  claimed: boolean;
+  tables: DetectedTable[];
+}
+
+export interface FormatImporter {
+  // Stable identity for registry bookkeeping and conflict messages.
+  id: string;
+  displayName: string;
+  // Scan the directory without materializing anything into DuckDB.
+  detect(dataDir: string): Promise<DetectionResult>;
+  // Materialize one table in canonical shape; returns the stored row count.
+  load(db: HealthDataDB, table: DetectedTable): Promise<number>;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -57,7 +57,7 @@ const schemaTool = new HealthSchemaTool(db, catalog, loader);
 // Create MCP server
 const server = new Server({
   name: "apple-health-mcp",
-  version: "1.4.1",
+  version: "1.4.2",
 }, {
   capabilities: {
     tools: {},

--- a/src/server.ts
+++ b/src/server.ts
@@ -14,8 +14,9 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 
 import { HealthDataDB } from "./db/database.js";
-import { FileCatalog } from "./db/catalog.js";
+import { FileCatalog, projectTableInfo } from "./db/catalog.js";
 import { TableLoader } from "./db/loader.js";
+import { defaultRegistry } from "./importers/index.js";
 import { QueryCache } from "./core/cache.js";
 import { MemoryManager } from "./core/memory.js";
 import { HealthQueryTool } from "./tools/health-query.js";
@@ -43,7 +44,7 @@ if (!DATA_DIR) {
 
 // Initialize components
 const db = new HealthDataDB({ dataDir: DATA_DIR, maxMemoryMB: MAX_MEMORY_MB });
-const catalog = new FileCatalog(DATA_DIR);
+const catalog = new FileCatalog(DATA_DIR, defaultRegistry());
 const loader = new TableLoader(db, catalog);
 const cache = new QueryCache(CACHE_SIZE);
 const memoryManager = new MemoryManager(db, catalog, loader, MAX_MEMORY_MB);
@@ -191,15 +192,9 @@ server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
       } catch {
         // keep the existing catalog
       }
-      // Report table names only; catalog entries also hold local file paths,
-      // which stay out of protocol responses.
-      const tables = Object.entries(catalog.getTableInfo())
-        .map(([name, entry]) => ({
-          name,
-          loaded: entry.loaded,
-          rowCount: entry.rowCount
-        }))
-        .sort((a, b) => a.name.localeCompare(b.name));
+      // Report table names only; catalog entries also hold local file paths
+      // and importer references, which stay out of protocol responses.
+      const tables = projectTableInfo(catalog.getTableInfo());
       return {
         contents: [{
           uri,

--- a/src/server.ts
+++ b/src/server.ts
@@ -195,11 +195,23 @@ server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
       // Report table names only; catalog entries also hold local file paths
       // and importer references, which stay out of protocol responses.
       const tables = projectTableInfo(catalog.getTableInfo());
+      // Keep parity with health_schema: a recorded multi-format conflict is
+      // visible on this surface too, so resource-only clients learn that new
+      // files are not being picked up.
+      const conflict = catalog.getScanConflict();
       return {
         contents: [{
           uri,
           mimeType: "application/json",
-          text: JSON.stringify({ totalTables: tables.length, tables }, jsonReplacer, 2)
+          text: JSON.stringify(
+            {
+              totalTables: tables.length,
+              tables,
+              ...(conflict ? { scanWarning: conflict.message } : {})
+            },
+            jsonReplacer,
+            2
+          )
         }]
       };
     }

--- a/src/test-helpers/conformance.ts
+++ b/src/test-helpers/conformance.ts
@@ -1,0 +1,202 @@
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { HealthDataDB } from '../db/database';
+import { FileCatalog } from '../db/catalog';
+import { TableLoader } from '../db/loader';
+import { ImporterRegistry } from '../importers/registry';
+import type { FormatImporter } from '../importers/types';
+
+// What a format's fixture writer must produce so the shared invariants can be
+// asserted against it. Every table name is the canonical lowercase HK
+// identifier the importer is expected to detect.
+export interface ConformanceExpectations {
+  // Quantity-kind table containing, in any order:
+  // - `validRows` rows with numeric values and valid timestamps, one of which
+  //   is dated decades in the past (year `oldRowYear`)
+  // - one row whose value is the non-numeric text `nonNumericValueText`
+  //   (loads with numeric value NULL, text preserved)
+  // - one row with an unparseable startDate (excluded)
+  // - one row with an empty value (excluded)
+  // - one row with an unparseable endDate (still loads)
+  quantityTable: string;
+  validRows: number;
+  oldRowYear: number;
+  nonNumericValueText: string;
+  // Category-kind table with at least one row labeled `categoryLabel`.
+  categoryTable: string;
+  categoryLabel: string;
+  // Workout-kind table whose single row spans `workoutDurationSeconds` between
+  // startDate and endDate and carries the format-specific `workoutColumn`.
+  workoutTable: string;
+  workoutColumn: string;
+  workoutDurationSeconds: number;
+  // A recognized file that yields zero loadable rows.
+  emptyTable: string;
+  // A recognized file whose load must fail (and leave no partial table).
+  brokenTable: string;
+}
+
+// End-to-end importer integration suite: wires a real catalog, loader, and
+// DuckDB around the importer and asserts the canonical table contract every
+// format must satisfy. Format-specific quirks belong in per-importer tests.
+export function runFormatConformance(
+  importer: FormatImporter,
+  writeFixtures: (dir: string) => ConformanceExpectations
+): void {
+  describe(`format conformance: ${importer.displayName}`, () => {
+    let dataDir: string;
+    let db: HealthDataDB;
+    let catalog: FileCatalog;
+    let loader: TableLoader;
+    let expected: ConformanceExpectations;
+
+    beforeAll(async () => {
+      dataDir = mkdtempSync(join(tmpdir(), 'format-conformance-'));
+      expected = writeFixtures(dataDir);
+
+      db = new HealthDataDB({ dataDir, maxMemoryMB: 512 });
+      await db.initialize();
+      catalog = new FileCatalog(dataDir, new ImporterRegistry([importer]));
+      await catalog.initialize();
+      loader = new TableLoader(db, catalog);
+    });
+
+    afterAll(async () => {
+      await db.close();
+      rmSync(dataDir, { recursive: true, force: true });
+    });
+
+    async function columnTypes(table: string): Promise<Map<string, string>> {
+      const columns = await db.execute(`
+        SELECT column_name, data_type
+        FROM information_schema.columns
+        WHERE table_name = '${table}'
+      `);
+      return new Map(
+        columns.map((col: any) => [String(col.column_name).toLowerCase(), String(col.data_type)])
+      );
+    }
+
+    async function tableExists(table: string): Promise<boolean> {
+      const result = await db.execute(`
+        SELECT COUNT(*) as count FROM information_schema.tables
+        WHERE table_name = '${table}'
+      `);
+      return Number(result[0]?.count ?? 0) > 0;
+    }
+
+    test('detection produces canonical lowercase names with correct kinds', () => {
+      const tables = catalog.getAllTables();
+      expect(tables).toContain(expected.quantityTable);
+      expect(tables).toContain(expected.categoryTable);
+      expect(tables).toContain(expected.workoutTable);
+      expect(tables).toContain(expected.emptyTable);
+      for (const name of tables) {
+        expect(name).toBe(name.toLowerCase());
+      }
+      expect(catalog.getEntry(expected.quantityTable)?.kind).toBe('quantity');
+      expect(catalog.getEntry(expected.categoryTable)?.kind).toBe('category');
+      expect(catalog.getEntry(expected.workoutTable)?.kind).toBe('workout');
+    });
+
+    test('a detected table is not materialized until first requested', async () => {
+      expect(await tableExists(expected.quantityTable)).toBe(false);
+      await loader.ensureTableLoaded(expected.quantityTable);
+      expect(await tableExists(expected.quantityTable)).toBe(true);
+    });
+
+    test('quantity rows land typed: timestamps, numeric value, preserved text', async () => {
+      await loader.ensureTableLoaded(expected.quantityTable);
+      const types = await columnTypes(expected.quantityTable);
+      expect(types.get('startdate')).toBe('TIMESTAMP');
+      if (types.has('enddate')) {
+        expect(types.get('enddate')).toBe('TIMESTAMP');
+      }
+      expect(types.get('value')).toBe('DOUBLE');
+
+      // Raw text survives alongside the numeric cast.
+      const nonNumeric = await db.execute(`
+        SELECT value, valueText FROM ${expected.quantityTable}
+        WHERE valueText = '${expected.nonNumericValueText}'
+      `);
+      expect(nonNumeric.length).toBe(1);
+      expect(nonNumeric[0].value).toBeNull();
+    });
+
+    test('row exclusions match the contract', async () => {
+      await loader.ensureTableLoaded(expected.quantityTable);
+      // validRows + the non-numeric row + the invalid-endDate row survive;
+      // the invalid-startDate row and the empty-value row are excluded.
+      const result = await db.execute(
+        `SELECT COUNT(*) as count FROM ${expected.quantityTable}`
+      );
+      expect(Number(result[0].count)).toBe(expected.validRows + 2);
+
+      // endDate is not validated: the invalid-endDate row loads with NULL.
+      const nullEnd = await db.execute(`
+        SELECT COUNT(*) as count FROM ${expected.quantityTable} WHERE endDate IS NULL
+      `);
+      expect(Number(nullEnd[0].count)).toBe(1);
+    });
+
+    test('full history loads with no date window', async () => {
+      await loader.ensureTableLoaded(expected.quantityTable);
+      const result = await db.execute(`
+        SELECT COUNT(*) as count FROM ${expected.quantityTable}
+        WHERE EXTRACT(year FROM startDate) = ${expected.oldRowYear}
+      `);
+      expect(Number(result[0].count)).toBeGreaterThan(0);
+    });
+
+    test('load returns a row count equal to the stored count', async () => {
+      await loader.ensureTableLoaded(expected.quantityTable);
+      const stored = await db.execute(
+        `SELECT COUNT(*) as count FROM ${expected.quantityTable}`
+      );
+      expect(catalog.getEntry(expected.quantityTable)?.rowCount).toBe(
+        Number(stored[0].count)
+      );
+    });
+
+    test('category labels land in valueText with numeric value NULL', async () => {
+      await loader.ensureTableLoaded(expected.categoryTable);
+      const rows = await db.execute(`
+        SELECT value, valueText FROM ${expected.categoryTable}
+        WHERE valueText = '${expected.categoryLabel}'
+      `);
+      expect(rows.length).toBeGreaterThan(0);
+      expect(rows[0].value).toBeNull();
+    });
+
+    test('workout columns are retained and duration derives from timestamps', async () => {
+      await loader.ensureTableLoaded(expected.workoutTable);
+      const types = await columnTypes(expected.workoutTable);
+      expect(types.has(expected.workoutColumn.toLowerCase())).toBe(true);
+
+      const rows = await db.execute(`
+        SELECT DATE_DIFF('second', startDate, endDate) as seconds
+        FROM ${expected.workoutTable}
+      `);
+      expect(Number(rows[0].seconds)).toBe(expected.workoutDurationSeconds);
+    });
+
+    test('a file with no loadable rows produces an empty table marked loaded', async () => {
+      await loader.ensureTableLoaded(expected.emptyTable);
+      const entry = catalog.getEntry(expected.emptyTable);
+      expect(entry?.loaded).toBe(true);
+      expect(entry?.rowCount).toBe(0);
+      const result = await db.execute(
+        `SELECT COUNT(*) as count FROM ${expected.emptyTable}`
+      );
+      expect(Number(result[0].count)).toBe(0);
+    });
+
+    test('a failed load raises and leaves no partial table', async () => {
+      await expect(loader.ensureTableLoaded(expected.brokenTable)).rejects.toThrow();
+      expect(await tableExists(expected.brokenTable)).toBe(false);
+      expect(catalog.getEntry(expected.brokenTable)?.loaded).toBe(false);
+    });
+  });
+}

--- a/src/test-helpers/csv-fixtures.ts
+++ b/src/test-helpers/csv-fixtures.ts
@@ -1,0 +1,33 @@
+import { writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+// Simple Health Export CSV dialect: a literal `sep=,` first line, CRLF line
+// endings, and a trailing newline. Loader options (skip = 1, new_line) depend
+// on this exact shape, so every fixture goes through this one writer.
+export function writeCsv(dir: string, fileName: string, header: string, rows: string[]): void {
+  const lines = ['sep=,', header, ...rows];
+  writeFileSync(join(dir, fileName), lines.join('\r\n') + '\r\n');
+}
+
+export function formatTimestamp(date: Date): string {
+  return `${date.toISOString().slice(0, 19).replace('T', ' ')} +0000`;
+}
+
+export function daysAgo(days: number): Date {
+  const date = new Date();
+  date.setDate(date.getDate() - days);
+  return date;
+}
+
+export function daysAfter(anchor: Date, days: number): Date {
+  const date = new Date(anchor);
+  date.setDate(date.getDate() + days);
+  return date;
+}
+
+export const QUANTITY_HEADER =
+  'type,sourceName,sourceVersion,productType,device,startDate,endDate,unit,value';
+export const CATEGORY_HEADER =
+  'type,sourceName,sourceVersion,productType,device,startDate,endDate,value';
+export const WORKOUT_HEADER =
+  'type,sourceName,sourceVersion,startDate,endDate,duration,totalEnergyBurned,totalDistance';

--- a/src/tools/health-query.test.ts
+++ b/src/tools/health-query.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { HealthDataDB } from '../db/database';
 import { FileCatalog } from '../db/catalog';
+import { defaultRegistry } from '../importers';
 import { TableLoader } from '../db/loader';
 import { QueryCache } from '../core/cache';
 import { HealthQueryTool } from './health-query';
@@ -26,7 +27,7 @@ beforeAll(async () => {
 
   db = new HealthDataDB({ dataDir, maxMemoryMB: 512 });
   await db.initialize();
-  const catalog = new FileCatalog(dataDir);
+  const catalog = new FileCatalog(dataDir, defaultRegistry());
   await catalog.initialize();
   const loader = new TableLoader(db, catalog);
   tool = new HealthQueryTool(db, new QueryCache(10), loader);

--- a/src/tools/health-report.test.ts
+++ b/src/tools/health-report.test.ts
@@ -7,21 +7,19 @@ import { FileCatalog } from '../db/catalog';
 import { TableLoader } from '../db/loader';
 import { QueryCache } from '../core/cache';
 import { HealthReportTool } from './health-report';
+import {
+  writeCsv,
+  formatTimestamp,
+  daysAgo,
+  QUANTITY_HEADER,
+  CATEGORY_HEADER,
+  WORKOUT_HEADER
+} from '../test-helpers/csv-fixtures';
 
 const SLEEP_NIGHTS = 10;
 const ASLEEP_HOURS_PER_NIGHT = 8;
 const IN_BED_HOURS_PER_NIGHT = 9;
 const WORKOUT_MINUTES = 30;
-
-function formatTimestamp(date: Date): string {
-  return `${date.toISOString().slice(0, 19).replace('T', ' ')} +0000`;
-}
-
-function daysAgo(days: number): Date {
-  const date = new Date();
-  date.setDate(date.getDate() - days);
-  return date;
-}
 
 // Pin a time of day so every row for a night lands on the same calendar date.
 function dayAt(days: number, hours: number, minutes: number = 0): Date {
@@ -29,15 +27,6 @@ function dayAt(days: number, hours: number, minutes: number = 0): Date {
   date.setUTCHours(hours, minutes, 0, 0);
   return date;
 }
-
-function writeCsv(dir: string, fileName: string, header: string, rows: string[]): void {
-  const lines = ['sep=,', header, ...rows];
-  writeFileSync(join(dir, fileName), lines.join('\r\n') + '\r\n');
-}
-
-const QUANTITY_HEADER = 'type,sourceName,sourceVersion,productType,device,startDate,endDate,unit,value';
-const CATEGORY_HEADER = 'type,sourceName,sourceVersion,productType,device,startDate,endDate,value';
-const WORKOUT_HEADER = 'type,sourceName,sourceVersion,startDate,endDate,duration,totalEnergyBurned,totalDistance';
 
 function writeFixtures(dir: string, options: { heartRateOnly?: boolean } = {}): void {
   const heartRateRows: string[] = [];

--- a/src/tools/health-report.test.ts
+++ b/src/tools/health-report.test.ts
@@ -285,3 +285,46 @@ describe('HealthReportTool with a missing metric', () => {
     rmSync(emptyDir, { recursive: true, force: true });
   });
 });
+
+describe('HealthReportTool workout kind exclusion', () => {
+  test('selects only workout-kind tables, not workout-named quantity or other tables', async () => {
+    const kindDir = mkdtempSync(join(tmpdir(), 'health-report-kind-'));
+    writeFixtures(kindDir, { heartRateOnly: true });
+
+    // One genuine workout table with two workouts.
+    const rows: string[] = [];
+    for (let day = 1; day <= 2; day++) {
+      const start = formatTimestamp(dayAt(day, 17));
+      const end = formatTimestamp(dayAt(day, 17, WORKOUT_MINUTES));
+      rows.push(`HKWorkoutActivityTypeRunning,Apple Watch,10.0,${start},${end},${WORKOUT_MINUTES},400,5.5`);
+    }
+    writeCsv(kindDir, 'HKWorkoutActivityTypeRunning.csv', WORKOUT_HEADER, rows);
+
+    // Recognized but unverified family: contains "workout", kind is `other`,
+    // and must not feed the workout section.
+    const start = formatTimestamp(dayAt(3, 17));
+    const end = formatTimestamp(dayAt(3, 17, WORKOUT_MINUTES));
+    writeCsv(kindDir, 'HKWorkoutTypeIdentifierTest.csv', WORKOUT_HEADER, [
+      `HKWorkoutTypeIdentifierTest,Apple Watch,10.0,${start},${end},${WORKOUT_MINUTES},400,5.5`
+    ]);
+
+    const kindDb = new HealthDataDB({ dataDir: kindDir, maxMemoryMB: 512 });
+    await kindDb.initialize();
+    const kindCatalog = new FileCatalog(kindDir, defaultRegistry());
+    await kindCatalog.initialize();
+    const kindLoader = new TableLoader(kindDb, kindCatalog);
+    const kindReport = await new HealthReportTool(
+      kindDb,
+      new QueryCache(100),
+      kindCatalog,
+      kindLoader
+    ).execute({ report_type: 'weekly' });
+
+    const data = sectionByTitle(kindReport, 'Workouts').data;
+    expect(Number(data.totalWorkouts)).toBe(2);
+    expect(Number(data.workoutTypes)).toBe(1);
+
+    await kindDb.close();
+    rmSync(kindDir, { recursive: true, force: true });
+  });
+});

--- a/src/tools/health-report.test.ts
+++ b/src/tools/health-report.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { HealthDataDB } from '../db/database';
 import { FileCatalog } from '../db/catalog';
+import { defaultRegistry } from '../importers';
 import { TableLoader } from '../db/loader';
 import { QueryCache } from '../core/cache';
 import { HealthReportTool } from './health-report';
@@ -121,7 +122,7 @@ beforeAll(async () => {
   // Cold server: nothing loaded before the report runs.
   db = new HealthDataDB({ dataDir, maxMemoryMB: 512 });
   await db.initialize();
-  const catalog = new FileCatalog(dataDir);
+  const catalog = new FileCatalog(dataDir, defaultRegistry());
   await catalog.initialize();
   const loader = new TableLoader(db, catalog);
   const cache = new QueryCache(100);
@@ -212,7 +213,7 @@ describe('HealthReportTool over a historical period', () => {
 
     const oldDb = new HealthDataDB({ dataDir: oldDir, maxMemoryMB: 512 });
     await oldDb.initialize();
-    const catalog = new FileCatalog(oldDir);
+    const catalog = new FileCatalog(oldDir, defaultRegistry());
     await catalog.initialize();
     const loader = new TableLoader(oldDb, catalog);
     const reportTool = new HealthReportTool(oldDb, new QueryCache(100), catalog, loader);
@@ -240,7 +241,7 @@ describe('HealthReportTool when a table cannot load', () => {
 
     const brokenDb = new HealthDataDB({ dataDir: brokenDir, maxMemoryMB: 512 });
     await brokenDb.initialize();
-    const catalog = new FileCatalog(brokenDir);
+    const catalog = new FileCatalog(brokenDir, defaultRegistry());
     await catalog.initialize();
 
     // Point the catalog entry at a file that does not exist so the load throws.
@@ -266,7 +267,7 @@ describe('HealthReportTool with a missing metric', () => {
 
     const emptyDb = new HealthDataDB({ dataDir: emptyDir, maxMemoryMB: 512 });
     await emptyDb.initialize();
-    const catalog = new FileCatalog(emptyDir);
+    const catalog = new FileCatalog(emptyDir, defaultRegistry());
     await catalog.initialize();
     const loader = new TableLoader(emptyDb, catalog);
     const reportTool = new HealthReportTool(emptyDb, new QueryCache(100), catalog, loader);

--- a/src/tools/health-report.ts
+++ b/src/tools/health-report.ts
@@ -119,7 +119,7 @@ export class HealthReportTool {
   }
 
   private getWorkoutTables(): string[] {
-    return this.catalog.getAllTables().filter(name => name.startsWith('hkworkoutactivitytype'));
+    return this.catalog.getTablesByKind('workout');
   }
 
   private missingSection(title: string, metricLabel: string): ReportSection {

--- a/src/tools/health-schema.test.ts
+++ b/src/tools/health-schema.test.ts
@@ -8,6 +8,8 @@ import { defaultRegistry } from '../importers';
 import { TableLoader } from '../db/loader';
 import { HealthSchemaTool } from './health-schema';
 import { writeCsv, formatTimestamp, daysAgo } from '../test-helpers/csv-fixtures';
+import { ImporterRegistry } from '../importers/registry';
+import { SimpleCsvImporter } from '../importers/simple-csv/importer';
 
 const RECENT_HEART_RATE_ROWS = 120;
 const OLD_HEART_RATE_ROWS = 5;
@@ -257,5 +259,76 @@ describe('HealthSchemaTool rescan', () => {
       LIMIT 1
     `);
     expect(Number(rows[0].duration)).toBeGreaterThan(0);
+  });
+});
+
+describe('HealthSchemaTool workout classification', () => {
+  test('workout guidance uses catalog kinds, not name matching', async () => {
+    const kindDir = mkdtempSync(join(tmpdir(), 'health-schema-kind-'));
+    const stamp = formatTimestamp(daysAgo(1));
+    const workoutHeader =
+      'type,sourceName,sourceVersion,startDate,endDate,duration,totalEnergyBurned,totalDistance';
+    writeCsv(kindDir, 'HKWorkoutActivityTypeRunning.csv', workoutHeader, [
+      `HKWorkoutActivityTypeRunning,Apple Watch,10.0,${stamp},${stamp},1800,400,5.5`
+    ]);
+    // Contains "workout" in the name but is not a verified workout family;
+    // kind-based classification excludes it where substring matching would not.
+    writeCsv(kindDir, 'HKWorkoutTypeIdentifierTest.csv', workoutHeader, [
+      `HKWorkoutTypeIdentifierTest,Apple Watch,10.0,${stamp},${stamp},1800,400,5.5`
+    ]);
+
+    const kindDb = new HealthDataDB({ dataDir: kindDir, maxMemoryMB: 512 });
+    await kindDb.initialize();
+    const kindCatalog = new FileCatalog(kindDir, defaultRegistry());
+    await kindCatalog.initialize();
+    const kindLoader = new TableLoader(kindDb, kindCatalog);
+
+    const result = await new HealthSchemaTool(kindDb, kindCatalog, kindLoader).execute();
+
+    expect(result.commonPatterns.workouts).toEqual(['hkworkoutactivitytyperunning']);
+    // Matches what health_report selects: the same kind metadata.
+    expect(kindCatalog.getTablesByKind('workout')).toEqual(['hkworkoutactivitytyperunning']);
+
+    await kindDb.close();
+    rmSync(kindDir, { recursive: true, force: true });
+  });
+});
+
+describe('HealthSchemaTool with a mixed-format directory', () => {
+  test('surfaces the multi-format conflict instead of the empty-directory hint', async () => {
+    const mixedDir = mkdtempSync(join(tmpdir(), 'health-schema-mixed-'));
+    const stamp = formatTimestamp(daysAgo(1));
+    writeCsv(
+      mixedDir,
+      'HKQuantityTypeIdentifierHeartRate.csv',
+      'type,sourceName,sourceVersion,productType,device,startDate,endDate,unit,value',
+      [`HKQuantityTypeIdentifierHeartRate,Apple Watch,10.0,Watch7,1,${stamp},${stamp},count/min,72`]
+    );
+
+    const fakeImporter = {
+      id: 'fake-json',
+      displayName: 'Fake JSON Export',
+      detect: async () => ({ claimed: true, tables: [] }),
+      load: async () => 0
+    };
+    const mixedDb = new HealthDataDB({ dataDir: mixedDir, maxMemoryMB: 512 });
+    await mixedDb.initialize();
+    const mixedCatalog = new FileCatalog(
+      mixedDir,
+      new ImporterRegistry([new SimpleCsvImporter(), fakeImporter])
+    );
+    // Startup conflict: the server's degrade-don't-die handler swallows this.
+    await mixedCatalog.initialize().catch(() => {});
+    const mixedLoader = new TableLoader(mixedDb, mixedCatalog);
+
+    const result = await new HealthSchemaTool(mixedDb, mixedCatalog, mixedLoader).execute();
+
+    expect(result.error).toContain('Simple Health Export CSV');
+    expect(result.error).toContain('Fake JSON Export');
+    expect(result.suggestion).toContain('separate directories');
+    expect(result.suggestion).not.toContain('Check that HEALTH_DATA_DIR contains CSV files');
+
+    await mixedDb.close();
+    rmSync(mixedDir, { recursive: true, force: true });
   });
 });

--- a/src/tools/health-schema.test.ts
+++ b/src/tools/health-schema.test.ts
@@ -276,6 +276,14 @@ describe('HealthSchemaTool workout classification', () => {
     writeCsv(kindDir, 'HKWorkoutTypeIdentifierTest.csv', workoutHeader, [
       `HKWorkoutTypeIdentifierTest,Apple Watch,10.0,${stamp},${stamp},1800,400,5.5`
     ]);
+    // A real workout-named quantity identifier (iOS 18+): stays out of the
+    // workout classification but keeps its sampled details and unit hints.
+    writeCsv(
+      kindDir,
+      'HKQuantityTypeIdentifierWorkoutEffortScore.csv',
+      'type,sourceName,sourceVersion,productType,device,startDate,endDate,unit,value',
+      [`HKQuantityTypeIdentifierWorkoutEffortScore,Apple Watch,10.0,Watch7,1,${stamp},${stamp},appleEffortScore,5`]
+    );
 
     const kindDb = new HealthDataDB({ dataDir: kindDir, maxMemoryMB: 512 });
     await kindDb.initialize();
@@ -288,6 +296,11 @@ describe('HealthSchemaTool workout classification', () => {
     expect(result.commonPatterns.workouts).toEqual(['hkworkoutactivitytyperunning']);
     // Matches what health_report selects: the same kind metadata.
     expect(kindCatalog.getTablesByKind('workout')).toEqual(['hkworkoutactivitytyperunning']);
+    // The workout-named quantity table is still listed, still sampled for
+    // details/units — just not classified as a workout source.
+    expect(result.availableTables).toContain('hkquantitytypeidentifierworkouteffortscore');
+    expect(result.tableDetails['hkquantitytypeidentifierworkouteffortscore']).toBeDefined();
+    expect(result.commonPatterns.workouts).not.toContain('hkquantitytypeidentifierworkouteffortscore');
 
     await kindDb.close();
     rmSync(kindDir, { recursive: true, force: true });

--- a/src/tools/health-schema.test.ts
+++ b/src/tools/health-schema.test.ts
@@ -6,28 +6,14 @@ import { HealthDataDB } from '../db/database';
 import { FileCatalog } from '../db/catalog';
 import { TableLoader } from '../db/loader';
 import { HealthSchemaTool } from './health-schema';
+import { writeCsv, formatTimestamp, daysAgo } from '../test-helpers/csv-fixtures';
 
 const RECENT_HEART_RATE_ROWS = 120;
 const OLD_HEART_RATE_ROWS = 5;
 const TOTAL_HEART_RATE_ROWS = RECENT_HEART_RATE_ROWS + OLD_HEART_RATE_ROWS;
 
-function formatTimestamp(date: Date): string {
-  return `${date.toISOString().slice(0, 19).replace('T', ' ')} +0000`;
-}
-
-function daysAgo(days: number): Date {
-  const date = new Date();
-  date.setDate(date.getDate() - days);
-  return date;
-}
-
 // A fixed historical date proves the loader cannot depend on the wall clock.
 const OLD_EXPORT_DATE = new Date('2019-04-08T07:15:00Z');
-
-function writeCsv(dir: string, fileName: string, header: string, rows: string[]): void {
-  const lines = ['sep=,', header, ...rows];
-  writeFileSync(join(dir, fileName), lines.join('\r\n') + '\r\n');
-}
 
 let dataDir: string;
 let db: HealthDataDB;

--- a/src/tools/health-schema.test.ts
+++ b/src/tools/health-schema.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { HealthDataDB } from '../db/database';
 import { FileCatalog } from '../db/catalog';
+import { defaultRegistry } from '../importers';
 import { TableLoader } from '../db/loader';
 import { HealthSchemaTool } from './health-schema';
 import { writeCsv, formatTimestamp, daysAgo } from '../test-helpers/csv-fixtures';
@@ -68,7 +69,7 @@ beforeAll(async () => {
 
   db = new HealthDataDB({ dataDir, maxMemoryMB: 512 });
   await db.initialize();
-  catalog = new FileCatalog(dataDir);
+  catalog = new FileCatalog(dataDir, defaultRegistry());
   await catalog.initialize();
   loader = new TableLoader(db, catalog);
 
@@ -162,7 +163,7 @@ describe('HealthSchemaTool with an old-only export', () => {
 
     oldDb = new HealthDataDB({ dataDir: oldDir, maxMemoryMB: 512 });
     await oldDb.initialize();
-    const oldCatalog = new FileCatalog(oldDir);
+    const oldCatalog = new FileCatalog(oldDir, defaultRegistry());
     await oldCatalog.initialize();
     const oldLoader = new TableLoader(oldDb, oldCatalog);
 
@@ -201,7 +202,7 @@ describe('HealthSchemaTool with an unreadable export', () => {
 
     emptyDb = new HealthDataDB({ dataDir: emptyDir, maxMemoryMB: 512 });
     await emptyDb.initialize();
-    const emptyCatalog = new FileCatalog(emptyDir);
+    const emptyCatalog = new FileCatalog(emptyDir, defaultRegistry());
     await emptyCatalog.initialize();
     const emptyLoader = new TableLoader(emptyDb, emptyCatalog);
 

--- a/src/tools/health-schema.ts
+++ b/src/tools/health-schema.ts
@@ -47,7 +47,10 @@ export class HealthSchemaTool {
     // source health_report uses.
     const workoutTables = new Set(this.catalog.getTablesByKind('workout'));
 
-    // Load a sample from key tables to show structure (including workouts/distance for unit hints)
+    // Load a sample from key tables to show structure (including workouts/distance
+    // for unit hints). Sampling keeps the name heuristic alongside the kind so
+    // workout-adjacent quantity tables (e.g. WorkoutEffortScore) still get
+    // their details and unit hints shown; classification below stays kind-only.
     const sampleTables = availableTables
       .filter(name =>
         name.includes('heartrate') ||
@@ -56,6 +59,7 @@ export class HealthSchemaTool {
         name.includes('activeenergyburned') ||
         name.includes('distancewalkingrunning') ||
         name.includes('distancecycling') ||
+        name.includes('workout') ||
         workoutTables.has(name)
       )
       .slice(0, 8);

--- a/src/tools/health-schema.ts
+++ b/src/tools/health-schema.ts
@@ -25,14 +25,28 @@ export class HealthSchemaTool {
     // Get available tables from catalog
     const tableInfo = this.catalog.getTableInfo();
     const availableTables = Object.keys(tableInfo);
-    
+    const scanConflict = this.catalog.getScanConflict();
+
     if (availableTables.length === 0) {
+      // A multi-format directory looks exactly like an empty one from here;
+      // the generic hint would be actively misleading, so surface the
+      // conflict's actionable message instead.
+      if (scanConflict) {
+        return {
+          error: `Multiple export formats found: ${scanConflict.formats.join(', ')}`,
+          suggestion: scanConflict.message
+        };
+      }
       return {
         error: "No health data tables found",
         suggestion: "Check that HEALTH_DATA_DIR contains CSV files"
       };
     }
-    
+
+    // Workout classification comes from catalog kind metadata, the same
+    // source health_report uses.
+    const workoutTables = new Set(this.catalog.getTablesByKind('workout'));
+
     // Load a sample from key tables to show structure (including workouts/distance for unit hints)
     const sampleTables = availableTables
       .filter(name =>
@@ -42,7 +56,7 @@ export class HealthSchemaTool {
         name.includes('activeenergyburned') ||
         name.includes('distancewalkingrunning') ||
         name.includes('distancecycling') ||
-        name.includes('workout')
+        workoutTables.has(name)
       )
       .slice(0, 8);
     
@@ -142,9 +156,15 @@ export class HealthSchemaTool {
       heartRate: availableTables.filter(t => t.includes('heartrate')),
       activity: availableTables.filter(t => t.includes('stepcount') || t.includes('distance') || t.includes('calories')),
       sleep: availableTables.filter(t => t.includes('sleep')),
-      workouts: availableTables.filter(t => t.includes('workout')),
+      workouts: availableTables.filter(t => workoutTables.has(t)),
       vitals: availableTables.filter(t => t.includes('bloodpressure') || t.includes('temperature') || t.includes('oxygen'))
     };
+
+    // A conflict recorded over a previously valid catalog: the tables below
+    // are still queryable, but new files are not being picked up.
+    if (scanConflict) {
+      schema.scanWarning = scanConflict.message;
+    }
     
     // Add query tips
     schema.queryTips = [

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,14 @@
+import type { FormatImporter, TableKind } from './importers/types';
+
 export interface CatalogEntry {
   path: string;
   loaded: boolean;
   rowCount: number | null;
   lastAccessed?: Date;
+  // Attached by the registry at scan time; stripped from all serialized
+  // catalog output (health_schema, health://tables).
+  kind?: TableKind;
+  importer?: FormatImporter;
 }
 
 export interface QueryResult {


### PR DESCRIPTION
## Summary

Moves every piece of Simple-Health-Export-specific knowledge — filename recognition, CSV dialect, column projection, workout-table classification — out of `src/db/` and `src/tools/` into a new `src/importers/simple-csv/` module behind a small `FormatImporter` interface (`id`, `displayName`, `detect`, `load`), with an importer registry that enforces one export format per data directory. This is the foundation PR for the planned Apple Health XML and Health Auto Export importers: adding a format becomes a new directory under `src/importers/` plus fixtures for the shared conformance suite, with no changes to the catalog or loader.

Zero client-visible behavior change, verified by the existing suite passing without any assertion edits. One deliberate, documented exception: `health_schema`'s workout *classification* list is now kind-based (matching `health_report`) instead of name-substring-based, so workout-named non-workout identifiers (e.g. `HKQuantityTypeIdentifierWorkoutEffortScore`, iOS 18+) no longer appear under workouts guidance — they keep their sampled details and unit hints, and report-tool selection is unchanged.

## Key decisions

- **Canonical table names stay the lowercase HK identifiers** regardless of source format, so saved queries survive a future format switch.
- **One format per data directory.** Two importers claiming files is a recorded conflict, not a silent precedence pick (formats can differ in data semantics — HAE can be aggregated). The server keeps its degrade-don't-die startup; the conflict reaches the client through `health_schema`'s error/suggestion output and a `scanWarning` on `health://tables`. The status always reflects the most recent scan outcome and re-records on the next completed detection.
- **Table kinds are assigned at detection from the filename** (`quantity` / `category` / `workout` / `other`) and are the only source of tool-layer classification — no name pattern matching in tools. `other` exists so unverified identifier families never assert a shape.
- **The CSV load SQL moved verbatim** (`read_csv` options, `DESCRIBE` sniff, projection, exclusions, indexes) — relocated, not rewritten, so the DuckDB Neo bindings swap plan's byte-for-byte SQL assumptions stay intact. This PR is sequenced independently of that swap and takes 1.4.2 (the swap reserves 1.5.0).
- **`runFormatConformance(importer, fixtures)`** is an end-to-end contract suite (real catalog + loader + DuckDB): typed timestamps, `value`/`valueText` semantics, row exclusions, full-history loading, row-count accuracy, workout duration derivation, empty-file handling, failed-load cleanup, and lazy materialization. A second importer adopts it by supplying fixtures.

## Testing

- 95 tests pass (`npm test`), typecheck and build clean. Baseline was 70 tests; the existing 70 pass with diffs limited to shared-helper imports and catalog construction sites (the parity gate for this refactor).
- New coverage: registry claim/conflict semantics, importer detection (canonical names, kinds, suffix stripping), conflict lifecycle (record → supersede on unrelated failure → re-record → clear), duplicate-canonical-name resolution, `health://tables` projection field-stripping, kind-based workout selection in both tools, `WorkoutEffortScore` characterization, and the 10-invariant conformance suite run against simple-csv.
- Reviewed by an 8-persona code review plus an independent cross-model adversarial pass; all actionable findings applied (conflict-status lifecycle fix, sampling parity restore, kind-exclusion test).

## Post-Deploy Monitoring & Validation

Local stdio MCP server — no hosted runtime. Validation is release-shaped:
- After publishing, `npx @neiltron/apple-health-mcp` against a real Simple Health Export directory: `health_schema` lists the same tables as 1.4.1, workout sections populate, and stderr stays quiet on a healthy directory.
- Failure signal: any `health_schema` output-shape change against an unchanged export directory, or `Failed to load table` errors for files 1.4.1 loaded. Mitigation: `npm i @neiltron/apple-health-mcp@1.4.1` (no persistent state; rollback is version pinning).

## Known Residuals

Advisory, accepted for this PR:
- The multi-format conflict path is latent until a second importer registers (only simple-csv ships today); a startup conflict currently logs under the generic "could not read HEALTH_DATA_DIR" stderr prefix.
- `TableLoader.loadAllTables` still swallows per-table load failures silently (pre-existing; currently uncalled).
- A failed `DROP TABLE` during load-failure cleanup can mask the original load error (pre-existing shape, now shared by the importer contract).
- `server.ts`'s startup catch path has no end-to-end test (pre-existing; the tool-layer equivalent is tested).

Plan: `docs/plans/2026-08-17-001-refactor-format-importer-architecture-plan.md` (local).