### PR TITLE
fix(query): restore pre-lint behavior and emit valid CSV

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,11 @@ Tests use Bun. The published runtime requires Node.js 22 or newer.
   `health_report`
 - `src/core/`: query caching, lazy-load coordination, and memory management
 - `server.json`: MCP Registry metadata
+- `docs/solutions/`: documented solutions and decisions from past work (bugs,
+  tooling choices, patterns), organized by category with YAML frontmatter
+  (`module`, `tags`, `problem_type`) — relevant when working in documented areas
+- `CONCEPTS.md`: shared domain vocabulary (entities, named processes, status
+  concepts) — relevant when orienting to the codebase or discussing domain terms
 
 See `docs/architecture.md` for the runtime flow and `docs/querying.md` for the
 normalized data model.

--- a/src/core/memory.ts
+++ b/src/core/memory.ts
@@ -2,7 +2,7 @@ import type { HealthDataDB } from '../db/database';
 import type { FileCatalog } from '../db/catalog';
 import type { TableLoader } from '../db/loader';
 
-export interface MemoryStats {
+interface MemoryStats {
   maxMemoryMB: number;
   estimatedUsageMB: number;
   loadedTables: number;

--- a/src/db/catalog.ts
+++ b/src/db/catalog.ts
@@ -11,7 +11,7 @@ export interface ScanConflict {
   message: string;
 }
 
-export interface CatalogTableInfo {
+interface CatalogTableInfo {
   [tableName: string]: CatalogEntry;
 }
 

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -15,7 +15,7 @@ export interface PromptDefinition {
   }>;
 }
 
-export interface PromptMessages extends GetPromptResult {
+interface PromptMessages extends GetPromptResult {
   description: string;
   messages: Array<{
     role: "user";

--- a/src/tools/health-query.test.ts
+++ b/src/tools/health-query.test.ts
@@ -57,13 +57,22 @@ describe('HealthQueryTool accepted queries', () => {
 });
 
 describe('HealthQueryTool output formats', () => {
-  test('preserves existing CSV serialization for strings and composites', async () => {
+  test('separates CSV rows with real newlines and quotes composite values', async () => {
     const result = await tool.execute({
       query: "SELECT 'a,b' AS label, [1, 2] AS values",
       format: 'csv'
     });
 
-    expect(result).toBe('label,values\\n"a,b",1,2');
+    expect(result).toBe('label,values\n"a,b","1,2"');
+  });
+
+  test('doubles embedded quotes and quotes fields containing line breaks', async () => {
+    const result = await tool.execute({
+      query: `SELECT 'say "hi"' AS quoted, 'line1' || chr(10) || 'line2' AS multiline`,
+      format: 'csv'
+    });
+
+    expect(result).toBe('quoted,multiline\n"say ""hi""","line1\nline2"');
   });
 
   test('includes non-finite numbers in summary statistics', async () => {

--- a/src/tools/health-query.test.ts
+++ b/src/tools/health-query.test.ts
@@ -56,6 +56,36 @@ describe('HealthQueryTool accepted queries', () => {
   });
 });
 
+describe('HealthQueryTool output formats', () => {
+  test('preserves existing CSV serialization for strings and composites', async () => {
+    const result = await tool.execute({
+      query: "SELECT 'a,b' AS label, [1, 2] AS values",
+      format: 'csv'
+    });
+
+    expect(result).toBe('label,values\\n"a,b",1,2');
+  });
+
+  test('includes non-finite numbers in summary statistics', async () => {
+    const result = await tool.execute({
+      query:
+        "SELECT CAST('NaN' AS DOUBLE) AS nan, CAST('Infinity' AS DOUBLE) AS infinity",
+      format: 'summary'
+    });
+
+    expect(Number.isNaN(result.statistics.nan.min)).toBe(true);
+    expect(Number.isNaN(result.statistics.nan.max)).toBe(true);
+    expect(Number.isNaN(result.statistics.nan.avg)).toBe(true);
+    expect(result.statistics.nan.count).toBe(1);
+    expect(result.statistics.infinity).toEqual({
+      min: Infinity,
+      max: Infinity,
+      avg: Infinity,
+      count: 1
+    });
+  });
+});
+
 describe('HealthQueryTool rejected queries', () => {
   const rejected: Array<[string, string]> = [
     ["SET max_temp_directory_size = '10GB'", 'set'],

--- a/src/tools/health-query.ts
+++ b/src/tools/health-query.ts
@@ -3,8 +3,12 @@ import type { QueryCache } from '../core/cache';
 import type { TableLoader } from '../db/loader';
 import type { HealthQueryArgs, QueryResult, OutputFormat } from '../types';
 
-function isFiniteNumber(value: any): value is number {
-  return Number.isFinite(value);
+function isNumber(value: any): value is number {
+  return Object(value) instanceof Number && Object(value) !== value;
+}
+
+function isString(value: any): value is string {
+  return Object(value) instanceof String && Object(value) !== value;
 }
 
 export class HealthQueryTool {
@@ -96,7 +100,7 @@ export class HealthQueryTool {
     for (const row of result.rows) {
       lines.push(row.map(val => {
         const text = String(val ?? '');
-        return text.includes(',') ? `"${text}"` : text;
+        return isString(val) && val.includes(',') ? `"${text}"` : text;
       }).join(','));
     }
     
@@ -115,7 +119,7 @@ export class HealthQueryTool {
       
       // Add basic statistics for numeric columns
       const numericColumns = result.columns.filter((col, idx) =>
-        result.rows.some(row => isFiniteNumber(row[idx]))
+        result.rows.some(row => isNumber(row[idx]))
       );
       
       if (numericColumns.length > 0) {
@@ -125,7 +129,7 @@ export class HealthQueryTool {
           const colIdx = result.columns.indexOf(col);
           const values = result.rows
             .map(row => row[colIdx])
-            .filter(isFiniteNumber);
+            .filter(isNumber);
           
           if (values.length > 0) {
             summary.statistics[col] = {

--- a/src/tools/health-query.ts
+++ b/src/tools/health-query.ts
@@ -7,8 +7,12 @@ function isNumber(value: any): value is number {
   return Object(value) instanceof Number && Object(value) !== value;
 }
 
-function isString(value: any): value is string {
-  return Object(value) instanceof String && Object(value) !== value;
+// RFC 4180: a field whose text contains a comma, quote, or line break must
+// be quoted, with embedded quotes doubled. Quoting keys off the rendered
+// text, so composite values such as DuckDB lists stay a single field.
+function escapeCsvField(value: any): string {
+  const text = String(value ?? '');
+  return /[",\n\r]/.test(text) ? `"${text.replace(/"/g, '""')}"` : text;
 }
 
 export class HealthQueryTool {
@@ -92,19 +96,16 @@ export class HealthQueryTool {
   
   private formatAsCSV(result: QueryResult): string {
     const lines: string[] = [];
-    
+
     // Header
-    lines.push(result.columns.join(','));
-    
+    lines.push(result.columns.map(escapeCsvField).join(','));
+
     // Rows
     for (const row of result.rows) {
-      lines.push(row.map(val => {
-        const text = String(val ?? '');
-        return isString(val) && val.includes(',') ? `"${text}"` : text;
-      }).join(','));
+      lines.push(row.map(escapeCsvField).join(','));
     }
-    
-    return lines.join('\\n');
+
+    return lines.join('\n');
   }
   
   private formatAsSummary(result: QueryResult): any {

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -11,4 +11,10 @@ describe('jsonReplacer', () => {
 
     expect(jsonReplacer('value', tagged)).toBe(tagged);
   });
+
+  test('preserves boxed bigint values', () => {
+    const boxed = Object(12n);
+
+    expect(jsonReplacer('value', boxed)).toBe(boxed);
+  });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 export function jsonReplacer(key: string, value: any): any {
-  if (Object(value) instanceof BigInt) {
+  if (Object(value) instanceof BigInt && Object(value) !== value) {
     return BigInt.prototype.toString.call(value);
   }
   return value;


### PR DESCRIPTION
## Summary

Two fixes to `health_query` output. The first restores runtime behavior that the lint cleanup in #30 silently changed while removing `typeof` checks. The second deliberately fixes a CSV formatting bug that dates to the initial tools commit.

## Changes

**Restore pre-lint runtime behavior**
- summary statistics include NaN and Infinity numbers again
- boxed BigInt objects pass through `jsonReplacer` unconverted
- the replacement predicates are verified equivalent to the original `typeof` checks (including boxed primitives and spoofed type tags)
- privatize the return-contract interfaces introduced by the cleanup; add `docs/solutions/` and `CONCEPTS.md` to the repository code map

**Emit valid CSV**
- rows were joined with the literal characters `\n` since the initial tools commit, so every CSV export arrived as one line
- only string fields were quoted, letting composite values (DuckDB lists) with embedded commas split into extra columns
- now joins with real newlines and applies RFC 4180 quoting to headers and the rendered text of every field: quote on comma, quote, or line break; double embedded quotes

CSV parsing remains fully delegated to DuckDB `read_csv`; this only touches response serialization.

## Validation

- `npm run lint`, `npm test` — 101 passing (4 new regression tests), `npm run typecheck`, `npm run build`
- live stdio session against an actual Simple Health Export: schema discovery, json/csv/summary queries, weekly report, `InvalidParams` on malformed arguments, mutation statements rejected, stderr clean
- the CSV quoting fix was exercised on real data: a `list(DISTINCT sourceName)` field containing a comma now round-trips as one quoted field

## Post-Deploy Monitoring & Validation

- **Window/owner:** maintainer, first MCP client session after release
- **Healthy signals:** `format: 'csv'` responses contain one row per line and parse as CSV; summary statistics unchanged for finite data
- **Failure signals:** CSV rows misaligned or clients failing to parse query output
- **Mitigation:** revert this PR; no data rollback needed